### PR TITLE
fix delete all comments

### DIFF
--- a/src/commands/github-bot-delete-bot-comments.yml
+++ b/src/commands/github-bot-delete-bot-comments.yml
@@ -21,6 +21,7 @@ steps:
           if [ -z "$PR_NUMBER" ];
           then
             echo "No pull request (yet): do not try to delete commments"
+            exit 0
           fi
 
           if [ "<< parameters.really-delete-comments >>" != "true" ];

--- a/src/commands/github-bot-delete-bot-comments.yml
+++ b/src/commands/github-bot-delete-bot-comments.yml
@@ -18,6 +18,11 @@ steps:
           export PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | cut -d '/' -f 7)
           echo $CIRCLE_PULL_REQUEST $PR_NUMBER
 
+          if [ -z "$PR_NUMBER" ];
+          then
+            echo "No pull request (yet): do not try to delete commments"
+          fi
+
           if [ "<< parameters.really-delete-comments >>" != "true" ];
           then
             echo "Halted at step: do not actually delete comments"


### PR DESCRIPTION
We noticed that this command will error if you call it but the pull request isn't opened yet. The job version of this handles this scenario but we don't use that all the time