### PR TITLE
Avoid root perms for slack-notify-compact

### DIFF
--- a/src/commands/slack-notify-compact.yml
+++ b/src/commands/slack-notify-compact.yml
@@ -36,12 +36,12 @@ steps:
       when: on_fail
       name: Slack - Detecting Job Status (FAIL)
       command: |
-        echo 'export CCI_STATUS="fail"' >> $BASH_ENV
+        echo 'export CCI_STATUS="fail"' > /tmp/SLACK_JOB_STATUS
   - run:
       when: on_success
       name: Slack - Detecting Job Status (PASS)
       command: |
-        echo 'export CCI_STATUS="pass"' >> $BASH_ENV
+        echo 'export CCI_STATUS="pass"' > /tmp/SLACK_JOB_STATUS
   - run:
       when: always
       name: Slack - Sending Notification

--- a/src/scripts/alert-slack-notify.sh
+++ b/src/scripts/alert-slack-notify.sh
@@ -41,6 +41,7 @@ ShouldPost() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*"$ORB_TEST_ENV"}" = "$0" ]; then
+    . "/tmp/SLACK_JOB_STATUS"
     ShouldPost
     BuildMessageBody
     PostToSlack


### PR DESCRIPTION
## Motivation

I was trying to use the `slack-notify-compact` command within monorepo with a certain docker executor for renovate but was running into permission issues since it cant access `$BASH_ENV`, which is stored under `\usr`. 

## Context

This pr works around that by following the official slack's CCI orb implementation of writing a script to `\tmp` then calling it. I think this wasn't an issue before since other executors have a different `BASH_ENV` under `\tmp`? Not sure why this is, but this change unblocks me for now and shouldn't affect how it works. Looking for thoughts on this?

## Testing

Tested the dev orb on monorepo and no more perm issues.