### PR TITLE
add example file for deployment notifications

### DIFF
--- a/src/examples/deployment-notifications.yml
+++ b/src/examples/deployment-notifications.yml
@@ -1,0 +1,34 @@
+description: >
+  Sample example description.
+# Provide a use-case based example for using this orb.
+# Everything in the `usage` section will be displayed in the orb registry.
+# Comments are not retained.
+usage:
+  version: 2.1
+  orbs:
+    apollo-platform-oss-orb: apollo/internal-platform-orb@1.0.6
+
+  jobs:
+    build-and-deploy-it:
+      steps:
+        - run:
+            command: "echo 'I would build something'"
+        - run:
+            command: "echo 'and I would deploy it'"
+  workflows:
+    use-my-orb-to-build-then-alert-slack:
+      jobs:
+        - build-and-deploy-it
+        - apollo-platform-oss-orb/alert-slack:
+            name: Alert Slack about build!
+            channel: build-alerts
+            emoji: ':checkered_flag:'
+            notify: '*finished build* of app:my-example'
+            fail: '*failed build* of app:my-example'
+            requires:
+              - build-and-deploy-it
+            context:
+              - slack-orb
+            # ^^^ or whatever your context is named with your Slack token
+        # If you are doing just a build notification, use the command: slack-circleci-build
+        # this is for larger things like deploys

--- a/src/examples/deployment-notifications.yml
+++ b/src/examples/deployment-notifications.yml
@@ -10,7 +10,8 @@ usage:
 
   jobs:
     build-and-deploy-it:
-      docker: cimg/openjdk:17.0.3
+      docker:
+        - image: cimg/openjdk:17.0.3
       steps:
         - run:
             command: "echo 'I would build something'"

--- a/src/examples/deployment-notifications.yml
+++ b/src/examples/deployment-notifications.yml
@@ -10,6 +10,7 @@ usage:
 
   jobs:
     build-and-deploy-it:
+      docker: cimg/openjdk:17.0.3
       steps:
         - run:
             command: "echo 'I would build something'"


### PR DESCRIPTION
Starting to populate the examples folder again, including using the alert-slack job (which ugh probably should be called slack-alert) to note code deployments