### PR TITLE
Add helm-deploy command

### DIFF
--- a/src/commands/helm-deploy.yml
+++ b/src/commands/helm-deploy.yml
@@ -1,21 +1,33 @@
 description: >
-  Deploys Helm to ShuttleCrawler, assumes image version of component is set in .version
+  Deploys a Helm chart, assumes image version of component is set in .version
 parameters:
   app-name:
     type: string
-    description: Name of application to be deployed
+    description: Name of application to deploy
   environment:
     type: string
-    description: Environment to be deployed on (prod, staging, dev)
+    description: Environment to deploy to
+  channel:
+    type: string
+    default: deploys-staging
+    description: Slack channel to send notifications to
   component:
     type: string
-    description: Name of folder which contains the Helm Chart
+    description: Name of folder that contains the Helm Chart
   domain:
     type: string
     description: Domain (K8s namespace) to deploy to
+  fail:
+    type: string
+    default: <!subteam^SFNQZTE4Q>
+    description: Message to be included in slack notification on failure
   path:
     type: string
     description: Path to .chart folder of application
+  project-id-env-var:
+    type: string
+    default: GCLOUD_PROJECT_ID
+    description: Environment variable that contains the project ID to deploy to
   short-region:
     type: string
     default: usc1
@@ -32,10 +44,6 @@ parameters:
     type: boolean
     default: false
     description: If enabled, simulate an upgrade
-  channel:
-    type: string
-    description: Slack channel to send notifications to
-    default: deploys-staging
 steps:
 - checkout
 - gcp-authorize:
@@ -47,7 +55,7 @@ steps:
       gcloud container clusters get-credentials \
         platform-<< parameters.environment >>-<< parameters.region >>-cluster \
         --zone << parameters.region >> \
-        --project ${GCLOUD_PROJECT_ID}
+        --project ${<< parameters.project-id-env-var >>}
 - run:
     name: Preparing Helm upgrade parameters
     command: |
@@ -56,7 +64,7 @@ steps:
       params+=("-f values.yaml")
       params+=("--namespace=<< parameters.domain >>")
       params+=("--set global.environment=<< parameters.environment >>")
-      params+=("--set global.projectId=${GCLOUD_PROJECT_ID}")
+      params+=("--set global.projectId=${<< parameters.project-id-env-var >>}")
       params+=("--set global.shortRegion=<< parameters.short-region >>")
       params+=("--set global.region=<< parameters.region >>")
       params+=("--set global.registryRegion=<< parameters.registry-region >>")
@@ -95,4 +103,4 @@ steps:
           channel: << parameters.channel >>
           emoji: ':checkered_flag:'
           # The oncall subteam string is found from https://app.slack.com/client/T024JTSAP/DK3CTS2F4/user_groups
-          fail: '<!subteam^SFNQZTE4Q>'
+          fail: << parameters.fail >>

--- a/src/commands/helm-deploy.yml
+++ b/src/commands/helm-deploy.yml
@@ -1,0 +1,98 @@
+description: >
+  Deploys Helm to ShuttleCrawler, assumes image version of component is set in .version
+parameters:
+  app-name:
+    type: string
+    description: Name of application to be deployed
+  environment:
+    type: string
+    description: Environment to be deployed on (prod, staging, dev)
+  component:
+    type: string
+    description: Name of folder which contains the Helm Chart
+  domain:
+    type: string
+    description: Domain (K8s namespace) to deploy to
+  path:
+    type: string
+    description: Path to .chart folder of application
+  short-region:
+    type: string
+    default: usc1
+    description: Short-region to deploy Compute Engine resources
+  region:
+    type: string
+    default: us-central1
+    description: Region to deploy Compute Engine resources
+  registry-region:
+    type: string
+    default: us-central1
+    description: Region of Artifact Registry
+  dry-run:
+    type: boolean
+    default: false
+    description: If enabled, simulate an upgrade
+  channel:
+    type: string
+    description: Slack channel to send notifications to
+    default: deploys-staging
+steps:
+- checkout
+- oss-internal-platform-orb/gcp-authorize:
+    environment-variable-name: GCLOUD_SERVICE_ACCOUNT
+    do-helm-login: 'true'
+- run:
+    name: Setting up ShuttleCrawler Google and K8 context
+    command: |
+      gcloud container clusters get-credentials \
+        platform-<< parameters.environment >>-<< parameters.region >>-cluster \
+        --zone << parameters.region >> \
+        --project ${GCLOUD_PROJECT_ID}
+- run:
+    name: Preparing Helm upgrade parameters
+    command: |
+      params=(--atomic --install --cleanup-on-fail --debug)
+      [[ -f << parameters.path >>/.chart/<< parameters.component >>/<< parameters.environment >>.yaml ]] && params+=("-f << parameters.environment >>.yaml")
+      params+=("-f values.yaml")
+      params+=("--namespace=<< parameters.domain >>")
+      params+=("--set global.environment=<< parameters.environment >>")
+      params+=("--set global.projectId=${GCLOUD_PROJECT_ID}")
+      params+=("--set global.shortRegion=<< parameters.short-region >>")
+      params+=("--set global.region=<< parameters.region >>")
+      params+=("--set global.registryRegion=<< parameters.registry-region >>")
+      params+=("--set global.version=$(<.version)")
+      echo "export PARAMS=(${params[@]})" >> "$BASH_ENV"
+- run:
+    name: Building helm dependencies
+    working_directory: << parameters.path >>/.chart/<< parameters.component >>
+    command: |
+      echo "Building dependencies for the application '<< parameters.app-name >>-<< parameters.component >>'"
+      helm dependency build ./
+- when:
+    condition: << parameters.dry-run >>
+    steps:
+    - run:
+        name: Deploy and release (Dry-run)
+        working_directory: << parameters.path >>/.chart/<< parameters.component >>
+        command: |
+          echo "Dry-run of upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.version)"
+          helm upgrade << parameters.app-name >>->-<< parameters.component >> ./ --dry-run "${PARAMS[@]}"
+- unless:
+    condition: << parameters.dry-run >>
+    steps:
+      - oss-internal-platform-orb/slack-circleci-build:
+          notify: "*starting deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"
+          channel: << parameters.channel >>
+          emoji: ':ship:'
+      - run:
+          name: Deploy and release
+          working_directory: << parameters.path >>/.chart/<< parameters.component >>
+          command: |
+            echo "Upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.version)"
+            helm upgrade << parameters.app-name >>>-<< parameters.component >> ./ "${PARAMS[@]}"
+      - oss-internal-platform-orb/slack-circleci-build:
+          notify: "*finished deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"
+          channel: << parameters.channel >>
+          emoji: ':checkered_flag:'
+          # The oncall subteam string is found from https://app.slack.com/client/T024JTSAP/DK3CTS2F4/user_groups
+          fail: '<!subteam^SFNQZTE4Q>'

--- a/src/commands/helm-deploy.yml
+++ b/src/commands/helm-deploy.yml
@@ -80,7 +80,7 @@ steps:
 - unless:
     condition: << parameters.dry-run >>
     steps:
-      - oss-internal-platform-orb/slack-circleci-build:
+      - slack-circleci-build:
           notify: "*starting deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"
           channel: << parameters.channel >>
           emoji: ':ship:'
@@ -90,7 +90,7 @@ steps:
           command: |
             echo "Upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.version)"
             helm upgrade << parameters.app-name >>>-<< parameters.component >> ./ "${PARAMS[@]}"
-      - oss-internal-platform-orb/slack-circleci-build:
+      - slack-circleci-build:
           notify: "*finished deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"
           channel: << parameters.channel >>
           emoji: ':checkered_flag:'

--- a/src/commands/helm-deploy.yml
+++ b/src/commands/helm-deploy.yml
@@ -1,5 +1,5 @@
 description: >
-  Deploys a Helm chart, assumes image version of component is set in .version
+  Deploys a Helm chart, assumes image version of component is set in .microservice_version
 parameters:
   app-name:
     type: string
@@ -71,7 +71,7 @@ steps:
       params+=("--set global.shortRegion=<< parameters.short-region >>")
       params+=("--set global.region=<< parameters.region >>")
       params+=("--set global.registryRegion=<< parameters.registry-region >>")
-      params+=("--set global.version=$(<.version)")
+      params+=("--set global.version=$(<.microservice_version)")
       echo "export PARAMS=(${params[@]})" >> "$BASH_ENV"
 - run:
     name: Building helm dependencies
@@ -86,7 +86,7 @@ steps:
         name: Deploy and release (Dry-run)
         working_directory: << parameters.path >>/.chart/<< parameters.component >>
         command: |
-          echo "Dry-run of upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.version)"
+          echo "Dry-run of upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.microservice_version)"
           helm upgrade << parameters.app-name >>->-<< parameters.component >> ./ --dry-run "${PARAMS[@]}"
 - unless:
     condition: << parameters.dry-run >>
@@ -99,7 +99,7 @@ steps:
           name: Deploy and release
           working_directory: << parameters.path >>/.chart/<< parameters.component >>
           command: |
-            echo "Upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.version)"
+            echo "Upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.microservice_version)"
             helm upgrade << parameters.app-name >>>-<< parameters.component >> ./ "${PARAMS[@]}"
       - slack-circleci-build:
           notify: "*finished deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"

--- a/src/commands/helm-deploy.yml
+++ b/src/commands/helm-deploy.yml
@@ -38,7 +38,7 @@ parameters:
     default: deploys-staging
 steps:
 - checkout
-- oss-internal-platform-orb/gcp-authorize:
+- gcp-authorize:
     environment-variable-name: GCLOUD_SERVICE_ACCOUNT
     do-helm-login: 'true'
 - run:

--- a/src/commands/helm-deploy.yml
+++ b/src/commands/helm-deploy.yml
@@ -60,8 +60,11 @@ steps:
     name: Preparing Helm upgrade parameters
     command: |
       params=(--atomic --install --cleanup-on-fail --debug)
-      [[ -f << parameters.path >>/.chart/<< parameters.component >>/<< parameters.environment >>.yaml ]] && params+=("-f << parameters.environment >>.yaml")
       params+=("-f values.yaml")
+
+      # Apply environment-specific yaml if it exists
+      [[ -f << parameters.path >>/.chart/<< parameters.component >>/<< parameters.environment >>.yaml ]] && params+=("-f << parameters.environment >>.yaml")
+
       params+=("--namespace=<< parameters.domain >>")
       params+=("--set global.environment=<< parameters.environment >>")
       params+=("--set global.projectId=${<< parameters.project-id-env-var >>}")

--- a/src/jobs/helm-deploy.yml
+++ b/src/jobs/helm-deploy.yml
@@ -1,0 +1,109 @@
+description: >
+  Deploys a Helm chart, assumes image version of component is set in .microservice_version
+parameters:
+  app-name:
+    type: string
+    description: Name of application to deploy
+  environment:
+    type: string
+    description: Environment to deploy to
+  channel:
+    type: string
+    default: deploys-staging
+    description: Slack channel to send notifications to
+  component:
+    type: string
+    description: Name of folder that contains the Helm Chart
+  domain:
+    type: string
+    description: Domain (K8s namespace) to deploy to
+  fail:
+    type: string
+    default: <!subteam^SFNQZTE4Q> # The oncall subteam string is found from https://app.slack.com/client/T024JTSAP/DK3CTS2F4/user_groups
+    description: Message to be included in slack notification on failure
+  path:
+    type: string
+    description: Path to .chart folder of application
+  project-id-env-var:
+    type: string
+    default: GCLOUD_PROJECT_ID
+    description: Environment variable that contains the project ID to deploy to
+  short-region:
+    type: string
+    default: usc1
+    description: Short-region to deploy Compute Engine resources
+  region:
+    type: string
+    default: us-central1
+    description: Region to deploy Compute Engine resources
+  registry-region:
+    type: string
+    default: us-central1
+    description: Region of Artifact Registry
+  dry-run:
+    type: boolean
+    default: false
+    description: If enabled, simulate an upgrade
+executor:
+steps:
+- checkout
+- gcp-authorize:
+    environment-variable-name: GCLOUD_SERVICE_ACCOUNT
+    do-helm-login: 'true'
+- run:
+    name: Setting up ShuttleCrawler Google and K8 context
+    command: |
+      gcloud container clusters get-credentials \
+        platform-<< parameters.environment >>-<< parameters.region >>-cluster \
+        --zone << parameters.region >> \
+        --project ${<< parameters.project-id-env-var >>}
+- run:
+    name: Preparing Helm upgrade parameters
+    command: |
+      params=(--atomic --install --cleanup-on-fail --debug)
+      params+=("-f values.yaml")
+
+      # Apply environment-specific yaml if it exists
+      [[ -f << parameters.path >>/.chart/<< parameters.component >>/<< parameters.environment >>.yaml ]] && params+=("-f << parameters.environment >>.yaml")
+
+      params+=("--namespace=<< parameters.domain >>")
+      params+=("--set global.environment=<< parameters.environment >>")
+      params+=("--set global.projectId=${<< parameters.project-id-env-var >>}")
+      params+=("--set global.shortRegion=<< parameters.short-region >>")
+      params+=("--set global.region=<< parameters.region >>")
+      params+=("--set global.registryRegion=<< parameters.registry-region >>")
+      params+=("--set global.version=$(<.microservice_version)")
+      echo "export PARAMS=(${params[@]})" >> "$BASH_ENV"
+- run:
+    name: Building helm dependencies
+    working_directory: << parameters.path >>/.chart/<< parameters.component >>
+    command: |
+      echo "Building dependencies for the application '<< parameters.app-name >>-<< parameters.component >>'"
+      helm dependency build ./
+- when:
+    condition: << parameters.dry-run >>
+    steps:
+    - run:
+        name: Deploy and release (Dry-run)
+        working_directory: << parameters.path >>/.chart/<< parameters.component >>
+        command: |
+          echo "Dry-run of upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.microservice_version)"
+          helm upgrade << parameters.app-name >>->-<< parameters.component >> ./ --dry-run "${PARAMS[@]}"
+- unless:
+    condition: << parameters.dry-run >>
+    steps:
+      - slack-circleci-build:
+          notify: "*starting deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"
+          channel: << parameters.channel >>
+          emoji: ':ship:'
+      - run:
+          name: Deploy and release
+          working_directory: << parameters.path >>/.chart/<< parameters.component >>
+          command: |
+            echo "Upgrading the application '<< parameters.app-name >>>-<< parameters.component >>' version: $(<.microservice_version)"
+            helm upgrade << parameters.app-name >>>-<< parameters.component >> ./ "${PARAMS[@]}"
+      - slack-circleci-build:
+          notify: "*finished deploy* of << parameters.app-name >>->-<< parameters.component >> to platform-<< parameters.environment >>"
+          channel: << parameters.channel >>
+          emoji: ':checkered_flag:'
+          fail: << parameters.fail >>


### PR DESCRIPTION
## NOTE

Going to be closed and moved into private orb. See https://github.com/mdg-private/circleci-pde-orb/pull/25

## Context

Resolves https://github.com/mdg-private/circleci-pde-orb/issues/23

Adding helm deploys as a command to the internal platform orb, so it's standardized across the platform / makes it easier for new repos (such as Hermes) to integrate helm. This new `helm-deploy` command should be used in Monorepo / Cloud-router.

## What Changed

Added `helm-deploy` command. Assumes that the image version is set in a `.version` file (following the same pattern used in `cloud-router`). Not sure if its the best method, but its one way/seems like the best way to pass in a version? Open to thoughts on this.

## Notes

Needs further discussion tomorrow about potentially moving to private orb. Or it might be fine how it is now. Topics to discuss are passing in GCLOUD_PROJECT_ID, kubernetes cluster, platform-env for slack-circleci-build message.