### PR TITLE
main and job cancel script edge case implementations

### DIFF
--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -19,6 +19,7 @@ standard_headers = {}
 job_life_clock = datetime.timedelta(hours=2)
 job_midlife_warning = datetime.timedelta(hours=1)
 
+robot_committers = ["apollo-bot2"]
 
 def get_workflow_started_by(current_workflow):
     user_url = f"https://circleci.com/api/v2/user/{current_workflow['started_by']}"
@@ -40,6 +41,9 @@ def find_old_workflow_ids(repo_slug):
 
               if ( (created_at < (now - job_midlife_warning)) and (created_at > (now - job_life_clock))):
                   username = get_workflow_started_by(current_workflow)
+                  if username in robot_committers:
+                      continue
+
                   yield { "job_status": "age_warning", "name": current_workflow['name'], "id": current_workflow['id'], "username": username }
 
               if (created_at < (now - job_life_clock)):


### PR DESCRIPTION
We've discovered two interesting edge cases over the course of the last few months:

  1. If a developer pushes to a new branch, but that branch contains no new commits, but errors in CI, that status will be reflected in the commit's statuses. So check to see if the status is actually about the main branch or not
  2. If a bot makes commits (think Dependabot) don't try to alert the bot, but alert a person if required