### PR TITLE
more customizability for Slack's link to Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ workflows:
           github-token: GH_BOT_KEY
           context:
             - orb-publishing
+            - github-orb
           requires:
             - orb-tools/lint
             - orb-tools/pack

--- a/src/commands/slack-circleci-build.yml
+++ b/src/commands/slack-circleci-build.yml
@@ -19,6 +19,9 @@ parameters:
     type: string
     default: ''
     description: Textual reference for a prefixed emoji to be formatted into the message to Slack.
+  link:
+    type: string
+    default: 'https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID'
 steps:
   - run:
       name: Init...
@@ -42,7 +45,7 @@ steps:
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "<< parameters.emoji >> *gh:$CIRCLE_USERNAME* in ghrepo:$CIRCLE_PROJECT_REPONAME: << parameters.notify >> :link: <https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID|View on CircleCI>. <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|View on Github>"
+              "text": "<< parameters.emoji >> *gh:$CIRCLE_USERNAME* in ghrepo:$CIRCLE_PROJECT_REPONAME: << parameters.notify >> :link: <<< parameters.link >>|View on CircleCI>. <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|View on Github>"
             }
           }]
         }

--- a/src/commands/slack-circleci-build.yml
+++ b/src/commands/slack-circleci-build.yml
@@ -28,7 +28,7 @@ steps:
       command: |
         PARAMETERS_CHANNEL="<< parameters.channel >>"
         echo "export NOTIFICATION_CHANNEL=${PARAMETERS_CHANNEL:-$CHANNEL}" >> $BASH_ENV
-        echo "export NOTIFICATION_LINK="<< parameters.link >>" >> $BASH_ENV
+        echo "export NOTIFICATION_LINK=\"<< parameters.link >>\"" >> $BASH_ENV
   - run:
       name: Verify input...
       command: |

--- a/src/commands/slack-circleci-build.yml
+++ b/src/commands/slack-circleci-build.yml
@@ -21,13 +21,14 @@ parameters:
     description: Textual reference for a prefixed emoji to be formatted into the message to Slack.
   link:
     type: string
-    default: 'https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID'
+    default: "https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
 steps:
   - run:
       name: Init...
       command: |
         PARAMETERS_CHANNEL="<< parameters.channel >>"
         echo "export NOTIFICATION_CHANNEL=${PARAMETERS_CHANNEL:-$CHANNEL}" >> $BASH_ENV
+        echo "export NOTIFICATION_LINK="<< parameters.link >>" >> $BASH_ENV
   - run:
       name: Verify input...
       command: |
@@ -45,7 +46,7 @@ steps:
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "<< parameters.emoji >> *gh:$CIRCLE_USERNAME* in ghrepo:$CIRCLE_PROJECT_REPONAME: << parameters.notify >> :link: <<< parameters.link >>|View on CircleCI>. <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|View on Github>"
+              "text": "<< parameters.emoji >> *gh:$CIRCLE_USERNAME* in ghrepo:$CIRCLE_PROJECT_REPONAME: << parameters.notify >> :link: <$NOTIFICATION_LINK|View on CircleCI>. <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|View on Github>"
             }
           }]
         }


### PR DESCRIPTION
# Motivation

While the link to the running pipeline is awesome, sometimes that's just the wrong place to put the user and results in a situation where we land the user in one place but all the action is happening another place.

So, allow users of the slack-circleci-build command to override where the link goes