### PR TITLE
introduce changelog; allow customization of who did a slack-circleci-build, util circleci-stop-if command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,13 @@ parameters:
     type: string
     default: "dev:alpha"
 
+commands:
+  is-changelog-modified:
+    steps:
+      - run:
+          name: Did you update the CHANGELOG with this branch's modifications?
+          command: git diff main...HEAD --name-only | grep CHANGELOG
+
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   integration-test-1:
@@ -39,6 +46,12 @@ jobs:
             - "60:6b:bb:7e:68:74:ef:e1:ad:c0:50:e3:ee:14:44:d0"
       - nextgen-versioning/git-tag:
           tag-type: ''
+  apollo-checks:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - is-changelog-modified
 
 workflows:
   test-pack:
@@ -49,6 +62,7 @@ workflows:
       - shellcheck/check:
           dir: ./src/scripts
           exclude: SC2148,SC2001,SC1091,SC2086,SC2116,SC2046,SC2005,SC2002
+      - apollo-checks
       # optional: Run BATS tests against your scripts
       # Publish development version(s) of the orb.
       - orb-tools/publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [1.0.12] - 2023-01-20
+### Added
+  - circleci-stop-if command
+
+### Changed
+  - modifications to this orb now require updated CHANGELOG. Versions before this point will be documented in a best effort approach, going forward changelog entries are enforced.
+  - slack-circleci-build has an optional who-did-it parameter which allows overriding author information
+
+
+## [1.0.11] - 2023-01-03
+
+
+### Changed
+  - slack-circleci-build has an optional link parameter in case the default Circle URL does not work for your use case
+
+
+## [1.0.10] - 2022-12-07
+
+
+### Changed
+  - the long job canceller script has the following changes:
+    - better handles failures on branches that have not been pushed to
+    - handle situation where robot makes a commit and human merges it (page the human)
+    - don't warn robots to take action
+
+## [1.0.8] - 2022-11-30
+
+### Changed
+  - build fix
+
+## [1.0.7] - 2023-11-30
+### Added
+  - enrich-mustache-folder command
+  - git-diff-set-parameters command
+  - enrich-mustache-from-path-filter job
+
+### Changed
+  - better documentation for enrich-mustache command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.11] - 2023-01-03
 
-
 ### Changed
   - slack-circleci-build has an optional link parameter in case the default Circle URL does not work for your use case
 
 
 ## [1.0.10] - 2022-12-07
-
 
 ### Changed
   - the long job canceller script has the following changes:
@@ -34,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
   - build fix
+
 
 ## [1.0.7] - 2023-11-30
 ### Added

--- a/src/commands/circleci-stop-if.yml
+++ b/src/commands/circleci-stop-if.yml
@@ -1,6 +1,6 @@
 description: >-
   Helper command which will `halt` the entire execution of the running `job` if the value of
-  tested parameter is the value of the expectation parameter.
+  `value` parameter is the value of the `stop-if-value-is` parameter.
 
   Circle's "when" conditions are great, but you could use this as a pre-step in a workflow to avoid executing a job
 

--- a/src/commands/circleci-stop-if.yml
+++ b/src/commands/circleci-stop-if.yml
@@ -10,7 +10,7 @@ parameters:
     description: A value - maybe even a Circle parameter - to check
   stop-if-value-is:
     type: string
-    description: If the value parameter is this value, halt job execution. Job will still be green, but further steps will not happen
+    description: If the value parameter matches this value, halt job execution. Job will still be green, but further steps will not happen
 
 steps:
   - run:

--- a/src/commands/circleci-stop-if.yml
+++ b/src/commands/circleci-stop-if.yml
@@ -7,14 +7,14 @@ description: >-
 parameters:
   value:
     type: string
-  halt-if-value-is:
+  stop-if-value-is:
     type: string
 
 steps:
   - run:
       name: Halt if actual = expected
       command: |
-        if [ "<< parameters.value >>" = "<< parameters.halt-if-value-is >>" ];
+        if [ "<< parameters.value >>" = "<< parameters.stop-if-value-is >>" ];
         then
           circleci-agent step halt
         fi

--- a/src/commands/circleci-stop-if.yml
+++ b/src/commands/circleci-stop-if.yml
@@ -7,8 +7,10 @@ description: >-
 parameters:
   value:
     type: string
+    description: A value - maybe even a Circle parameter - to check
   stop-if-value-is:
     type: string
+    description: If the value parameter is this value, halt job execution. Job will still be green, but further steps will not happen
 
 steps:
   - run:

--- a/src/commands/circleci-stop-if.yml
+++ b/src/commands/circleci-stop-if.yml
@@ -2,19 +2,19 @@ description: >-
   Helper command which will `halt` the entire execution of the running `job` if the value of
   tested parameter is the value of the expectation parameter.
 
-  when conditions are great, but you could use this as a pre-step in a workflow to avoid executing a job
+  Circle's "when" conditions are great, but you could use this as a pre-step in a workflow to avoid executing a job
 
 parameters:
-  tested:
+  value:
     type: string
-  expectation:
+  halt-if-value-is:
     type: string
 
 steps:
   - run:
-      name: Halt if tested = expectation
+      name: Halt if actual = expected
       command: |
-        if [ "<< parameters.tested >>" = "<< parameters.expectation >>" ];
+        if [ "<< parameters.value >>" = "<< parameters.halt-if-value-is >>" ];
         then
           circleci-agent step halt
         fi

--- a/src/commands/circleci-stop-if.yml
+++ b/src/commands/circleci-stop-if.yml
@@ -1,6 +1,8 @@
 description: >-
   Helper command which will `halt` the entire execution of the running `job` if the value of
-  tested parameter is the value of the expectation parameter
+  tested parameter is the value of the expectation parameter.
+
+  when conditions are great, but you could use this as a pre-step in a workflow to avoid executing a job
 
 parameters:
   tested:

--- a/src/commands/slack-circleci-build.yml
+++ b/src/commands/slack-circleci-build.yml
@@ -22,6 +22,10 @@ parameters:
   link:
     type: string
     default: "https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
+  who-did-it:
+    type: string
+    description: Who did the action
+    default: "gh:$CIRCLE_USERNAME"
 steps:
   - run:
       name: Init...
@@ -46,7 +50,7 @@ steps:
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "<< parameters.emoji >> *gh:$CIRCLE_USERNAME* in ghrepo:$CIRCLE_PROJECT_REPONAME: << parameters.notify >> :link: <$NOTIFICATION_LINK|View on CircleCI>. <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|View on Github>"
+              "text": "<< parameters.emoji >> *<< parameters.who-did-it >>* in ghrepo:$CIRCLE_PROJECT_REPONAME: << parameters.notify >> :link: <$NOTIFICATION_LINK|View on CircleCI>. <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|View on Github>"
             }
           }]
         }

--- a/src/commands/stop-if.yml
+++ b/src/commands/stop-if.yml
@@ -1,0 +1,18 @@
+description: >-
+  Helper command which will `halt` the entire execution of the running `job` if the value of
+  tested parameter is the value of the expectation parameter
+
+parameters:
+  tested:
+    type: string
+  expectation:
+    type: string
+
+steps:
+  - run:
+      name: Halt if tested = expectation
+      command: |
+        if [ "<< parameters.tested >>" = "<< parameters.expectation >>" ];
+        then
+          circleci-agent step halt
+        fi


### PR DESCRIPTION
This PR contains a bunch of separate changes (sorry about that)

  1. A CHANGELOG, and mechanism to make sure it's updated
  2. New circleci-stop-if command
  3. Allow existing slack-circleci-build to take in person string (sometimes the user that is running the build isn't enough)

# Motivation

The changelog allows better visibility as more teams or contributors edit this under potentially less supervision.

circle-stop-if allows Circle conditional logic in places where it previously wasn't allowed

slack-circleci-build we wanted to override the person string

