### PR TITLE
Fix/pagination for cancellations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13] - 2023-01-23
+
+### Fixed
+- The Command `circleci-continue-long-job-cancel` did not have the ability to properly paginate
+  over results. This release makes it such that the Cancel command will now walk over a period of
+  time, instead of a set number of pages.
 
 ## [1.0.12] - 2023-01-20
 ### Added

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -18,7 +18,7 @@ steps:
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --just-do-it
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/scripts/circleci-job-canceller/Modules/circle_utils.py
+++ b/src/scripts/circleci-job-canceller/Modules/circle_utils.py
@@ -1,28 +1,30 @@
 import requests
 import pprint
 
-go_back_page_limit = 5  # set me to None to go back ALL the way, which you'll need to do once (only?)
 
-def get_all_items(relative_url, headers):
+def get_all_items(relative_url, headers, pagination_limit=5):
     url = f"https://circleci.com/api/v2{relative_url}"
     temp_url = str(url)
     pages_iterated = 0
     while True:
         res = requests.get(temp_url, headers=headers).json()
         try:
-            yield from res["items"]  # delegates iteration to the (list), so returns 1 by one...
+            # delegates iteration to the (list), so returns 1 by one...
+            yield from res["items"]
         except KeyError as e:
             print(e)
             pprint.pprint(res)
             print(url)
             raise e
+
         page_token = res.get("next_page_token")
+
         if page_token is not None:
             temp_url = f"{url}?page-token={page_token}"
             pages_iterated += 1
         else:
             break
 
-        if (go_back_page_limit and (pages_iterated >= go_back_page_limit)):
+        if (pagination_limit and (pages_iterated >= pagination_limit)):
             print("page limit hit")
             break

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -60,18 +60,6 @@ def find_old_workflow_ids(repo_slug, window_start, window_end, headers):
                     yield {"job_status": "too_old", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
 
 
-def cancel_pipeline(pipeline, workflows):
-    for workflow in workflows:
-        if not workflow.get('stopped_at'):
-            print(
-                f'    Cancelling workflow: https://app.circleci.com/pipelines/{pipeline["project_slug"]}/{pipeline["number"]}/workflows/{workflow["id"]}')
-            response = requests.post(
-                f"https://circleci.com/api/v2/workflow/{current_info['id']}/cancel", headers=standard_headers)
-
-            if not response['message'] == 'Accepted.':
-                raise Exception(f'{response}')
-
-
 def main(circleapitoken, orgreposlug, output_file, commit):
     standard_headers = {"Circle-Token": circleapitoken}
 

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -12,8 +12,6 @@ import argparse
 
 sys.path.append("..")  # added!
 
-standard_headers = {}
-
 
 job_life_clock = datetime.timedelta(hours=2)
 job_midlife_warning = datetime.timedelta(hours=1)
@@ -21,34 +19,36 @@ job_midlife_warning = datetime.timedelta(hours=1)
 robot_committers = ["apollo-bot2"]
 
 
-def get_workflow_started_by(current_workflow):
+def get_workflow_started_by(current_workflow, headers):
     user_url = f"https://circleci.com/api/v2/user/{current_workflow['started_by']}"
-    user_info = requests.get(user_url, headers=standard_headers).json()
+    user_info = requests.get(user_url, headers=headers).json()
     # the Github / CircleCI scheduling bot won't have a username (JSON body will be {'message': 'Not found.'})
     username = user_info.get("login", "")
 
     return username
 
 
-def find_old_workflow_ids(repo_slug):
+def find_old_workflow_ids(repo_slug, headers):
     utc_tz = datetime.timezone(datetime.timedelta(hours=0))
     now = datetime.datetime.now(utc_tz)
 
-    for current_pipeline in get_all_items(f"/project/gh/{repo_slug}/pipeline", standard_headers):
-        for current_workflow in get_all_items(f"/pipeline/{current_pipeline['id']}/workflow", standard_headers):
+    for current_pipeline in get_all_items(f"/project/gh/{repo_slug}/pipeline", headers):
+        for current_workflow in get_all_items(f"/pipeline/{current_pipeline['id']}/workflow", headers):
             if current_workflow["status"] == "on_hold":
                 created_at_str = current_workflow["created_at"]
                 created_at = isoparse(created_at_str)
 
                 if ((created_at < (now - job_midlife_warning)) and (created_at > (now - job_life_clock))):
-                    username = get_workflow_started_by(current_workflow)
+                    username = get_workflow_started_by(
+                        current_workflow, headers)
                     if username in robot_committers:
                         continue
 
                     yield {"job_status": "age_warning", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
 
                 if (created_at < (now - job_life_clock)):
-                    username = get_workflow_started_by(current_workflow)
+                    username = get_workflow_started_by(
+                        current_workflow, headers)
                     yield {"job_status": "too_old", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
 
 
@@ -73,9 +73,10 @@ if __name__ == "__main__":
 
     simple_path = os.path.abspath(os.path.expanduser(
         os.path.expandvars(args.output_file)))
+
     with open(simple_path, 'w') as f:
         f.write("job_status\tproceed\tid\tusername\tname\n")
-        for current_info in find_old_workflow_ids(args.orgreposlug, ):
+        for current_info in find_old_workflow_ids(args.orgreposlug, standard_headers):
             if current_info["job_status"] == "age_warning":
                 print(
                     f"midlife warning for workflow ({current_info['name']}), started by gh:{current_info['username']}. See more info at: https://app.circleci.com/pipelines/workflows/{current_info['id']}")


### PR DESCRIPTION
# Motivation

Every so often we are seeing an instance where a handful of Pipelines/Workflows are _not_ being cancelled/tidied up. Instead of paginating back a specified amount, we can instead find _all_ Pipelines which fall in between some window where we wish to tidy things up. Presently, this is set to 10 hours ago, to 1 hour ago.

## Notes

Best to review commit by commit. Not every one is atomic, but should make that linting noise simpler to deal with.

## Suggested Musical Pairing

https://soundcloud.com/sminoworld/no-ls