### PR TITLE
allow the age warning to ignore on hold jobs with certain words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # orb.yml is "packed" from source, and not published directly from the repository.
 orb.yml
 .DS_Store
+__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.0.19] - 2023-02-03
+## [1.0.19] - 2023-02-06
 ### Added
 
   - The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold (aka yet to be approved approval jobs) have a name containing specified words

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.14] - 2023-01-26
+### Added
+
+  - The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold jobs waiting have a name that contains the text in the ignore-jobs-with-name parameter
+
 ## [1.0.13] - 2023-01-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.18] - 2023-02-02
 ### Added
 
-  - The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold jobs waiting have a name that contains the text in the ignore-jobs-with-name parameter
+  - The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold (aka yet to be approved approval jobs) have a name containing specified words
 
 ## [1.0.17] - 2023-01-27
 

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -12,7 +12,7 @@ parameters:
     default: "CIRCLECI_TOKEN"
     type: string
   ignore-jobs-containing:
-    description: do not warn people about workflows where all the on hold job names contain this string
+    description: do not warn people about workflows where all the on hold job names contain this string. Multiple strings seperated by comma, eg development,delete
     type: string
     default: ""
   n-windows:

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -11,7 +11,7 @@ parameters:
     description: the name of the environmental variable that contains the circleci token
     default: "CIRCLECI_TOKEN"
     type: string
-  ignore-when-all-on-hold-jobs-contain:
+  ignore-when-all-on-hold-job-names-contain:
     description: Do not warn about workflows where all of the on hold job names contain this string (also supported - comma seperated list)
     type: string
     default: ""
@@ -25,7 +25,7 @@ steps:
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore=<< parameters.ignore-when-all-on-hold-jobs-contain >>
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore-job-names=<< parameters.ignore-when-all-on-hold-job-names-contain >>
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -11,6 +11,10 @@ parameters:
     description: the name of the environmental variable that contains the circleci token
     default: "CIRCLECI_TOKEN"
     type: string
+  ignore-jobs-with-name:
+    description: do not warn people about jobs with this name
+    type: string
+    default: ""
 
 steps:
   - run:
@@ -18,7 +22,7 @@ steps:
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --ignore=<< parameters.ignore-jobs-with-name >>
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -12,7 +12,7 @@ parameters:
     default: "CIRCLECI_TOKEN"
     type: string
   ignore-jobs-containing:
-    description: do not warn people about workflows where all the on hold job names contain this string. Multiple strings seperated by comma, eg development,delete
+    description: Do not warn about workflows where all of the on hold job names contain a string from this comma separated list
     type: string
     default: ""
   n-windows:

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -11,8 +11,8 @@ parameters:
     description: the name of the environmental variable that contains the circleci token
     default: "CIRCLECI_TOKEN"
     type: string
-  ignore-jobs-with-name:
-    description: do not warn people about jobs with this name
+  ignore-jobs-containing:
+    description: do not warn people about workflows where all the on hold job names contain this string
     type: string
     default: ""
 
@@ -22,7 +22,7 @@ steps:
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --ignore=<< parameters.ignore-jobs-with-name >>
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --ignore=<< parameters.ignore-jobs-containing >>
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -11,8 +11,8 @@ parameters:
     description: the name of the environmental variable that contains the circleci token
     default: "CIRCLECI_TOKEN"
     type: string
-  ignore-jobs-containing:
-    description: Do not warn about workflows where all of the on hold job names contain a string from this comma separated list
+  ignore-when-all-on-hold-jobs-contain:
+    description: Do not warn about workflows where all of the on hold job names contain this string (also supported - comma seperated list)
     type: string
     default: ""
   n-windows:
@@ -25,7 +25,7 @@ steps:
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore=<< parameters.ignore-jobs-containing >>
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore=<< parameters.ignore-when-all-on-hold-jobs-contain >>
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/scripts/circleci-job-canceller/Modules/circle_utils.py
+++ b/src/scripts/circleci-job-canceller/Modules/circle_utils.py
@@ -8,6 +8,10 @@ def get_all_items(relative_url, headers, pagination_limit=5):
     pages_iterated = 0
     while True:
         res = requests.get(temp_url, headers=headers).json()
+        if (res.get("message") == 'An internal server error occurred.'):
+            print("Circle side error hit")
+            break
+
         try:
             # delegates iteration to the (list), so returns 1 by one...
             yield from res["items"]

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -95,11 +95,10 @@ def do_we_care_about_this_pipeline(current_info, ignore, headers):
     # if all of them do, then we do NOT care about this pipeline
 
     not_ignored_jobs = itertools.dropwhile( lambda x: x['name'].find(ignore) > -1 , pending_approvals )
-
     amount_we_still_care_about = len(list(not_ignored_jobs))
-    output = amount_we_still_care_about > 0
+
     print(f"Workflow initially had {len(pending_approvals)} approval jobs, {amount_we_still_care_about} we care about")
-    return ( output )
+    return (  amount_we_still_care_about > 0 )
 
 
 def main(circleapitoken, orgreposlug, n_windows, output_file, commit, ignore):
@@ -119,7 +118,7 @@ def main(circleapitoken, orgreposlug, n_windows, output_file, commit, ignore):
             if current_info["job_status"] == "age_warning":
                 if not do_we_care_about_this_pipeline(current_info, ignore, standard_headers):
                     if not (ignore == ""):
-                        print("we do not care about this pipeline - all jobs contained ignore word")
+                        print("we do not care about this pipeline - all awaiting approval jobs contained ignore word")
                     continue
                 print(
                     f"midlife warning for workflow ({current_info['name']}), started by gh:{current_info['username']}. See more info at: https://app.circleci.com/pipelines/workflows/{current_info['id']}")
@@ -152,7 +151,7 @@ if __name__ == "__main__":
                         help="Number of windows to look back across. Default window length is 2 hours.",
                         type=int,
                         default=6)
-    parser.add_argument("--ignore", help="ignore steps that contain this word", default="")
+    parser.add_argument("--ignore", help="if all awaiting approval jobs in the pipeline contain this word, do not age warn about it", default="")
 
     args = parser.parse_args()
 

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -93,14 +93,11 @@ def matches_any_in_list(str, list):
 
 
 def has_only_ignored_jobs(current_info, ignore, headers):
-    pending_approvals = get_workflow_pending_approval_jobs(current_info['id'], headers)
-
-    for current in itertools.filterfalse(
-            lambda x: matches_any_in_list(x['name'], ignore),
-            pending_approvals ):
-        # if we are here then we have a job name that is not filtered by our ignore list
-        # (so we do not _only_ have ignored jobs). Short circuit, the answer to our question is False
-        return False
+    for current in get_workflow_pending_approval_jobs(current_info['id'], headers):
+        if not matches_any_in_list(current['name'], ignore):
+          # if we are here then we have a job name that is not filtered by our ignore list
+          # (so we do not _only_ have ignored jobs). Short circuit, the answer to our question is False
+          return False
     return True
 
 
@@ -154,7 +151,7 @@ if __name__ == "__main__":
                         help="Number of windows to look back across. Default window length is 2 hours.",
                         type=int,
                         default=6)
-    parser.add_argument("--ignore", help="if all awaiting approval jobs in the pipeline contain this word, do not age warn about it. Multiple word supported by delimiting with ,", default="")
+    parser.add_argument("--ignore", help="if all awaiting approval jobs in the pipeline contain this word, do not age warn about it. Multiple word supported by delimiting with , (example: --ignore=optional,maybe). A job only has to match one of the words", default="")
 
     args = parser.parse_args()
 

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -94,7 +94,6 @@ def do_we_care_about_this_pipeline(current_info, ignore, headers):
     # we want to know if all of the names of the approval jobs waiting contain the ignore keyword
     # if all of them do, then we do NOT care about this pipeline
 
-    # TODO: handle case where ignore == "", which is the default for the Circle config
     not_ignored_jobs = itertools.dropwhile( lambda x: x['name'].find(ignore) > -1 , pending_approvals )
 
     amount_we_still_care_about = len(list(not_ignored_jobs))
@@ -118,9 +117,9 @@ def main(circleapitoken, orgreposlug, n_windows, output_file, commit, ignore):
             standard_headers
         ):
             if current_info["job_status"] == "age_warning":
-
                 if not do_we_care_about_this_pipeline(current_info, ignore, standard_headers):
-                    print("we do not care about this pipeline")
+                    if not (ignore == ""):
+                        print("we do not care about this pipeline - all jobs contained ignore word")
                     continue
                 print(
                     f"midlife warning for workflow ({current_info['name']}), started by gh:{current_info['username']}. See more info at: https://app.circleci.com/pipelines/workflows/{current_info['id']}")

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -88,7 +88,11 @@ def do_we_care_about_this_pipeline(current_info, ignore, headers):
     # we want to know if all of the names of the approval jobs waiting contain the ignore keyword
     # if all of them do, then we do NOT care about this pipeline
     not_ignored_jobs = itertools.dropwhile( lambda x: x['name'].find(ignore) > -1 , pending_approvals )
-    return ( len(list(not_ignored_jobs)) > 0 )
+
+    amount_we_still_care_about = len(list(not_ignored_jobs))
+    output = amount_we_still_care_about > 0
+    print(f"Workflow initially had {len(pending_approvals)} approval jobs, {amount_we_still_care_about} we care about")
+    return ( output )
 
 
 def main(circleapitoken, orgreposlug, output_file, commit, ignore):
@@ -106,6 +110,10 @@ def main(circleapitoken, orgreposlug, output_file, commit, ignore):
             standard_headers
         ):
             if current_info["job_status"] == "age_warning":
+
+                if not do_we_care_about_this_pipeline(current_info, ignore, standard_headers):
+                    print("we do not care about this pipeline")
+                    continue
                 print(
                     f"midlife warning for workflow ({current_info['name']}), started by gh:{current_info['username']}. See more info at: https://app.circleci.com/pipelines/workflows/{current_info['id']}")
             else:

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -119,7 +119,7 @@ def main(circleapitoken, orgreposlug, n_windows, output_file, commit, ignore):
             standard_headers
         ):
             if current_info["job_status"] == "age_warning":
-                if not (ignore == ""):
+                if not (ignore == ['']):
                     if has_only_ignored_jobs(current_info, ignore, standard_headers):
                         print(f"ignoring workflow: {current_info['id']} See more info at https://app.circleci.com/pipelines/workflows/{current_info['id']}")
                         continue

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -151,9 +151,9 @@ if __name__ == "__main__":
                         help="Number of windows to look back across. Default window length is 2 hours.",
                         type=int,
                         default=6)
-    parser.add_argument("--ignore", help="if all awaiting approval jobs in the pipeline contain this word, do not age warn about it. Multiple word supported by delimiting with , (example: --ignore=optional,maybe). A job only has to match one of the words", default="")
+    parser.add_argument("--ignore-job-names", help="if all awaiting approval jobs in the pipeline contain this word, do not age warn about it. Multiple word supported by delimiting with , (example: --ignore=optional,maybe). A job only has to match one of the words", default="")
 
     args = parser.parse_args()
 
     main(args.circleapitoken, args.orgreposlug,
-         args.n_windows, args.output_file, args.commit, args.ignore.split(","))
+         args.n_windows, args.output_file, args.commit, args.ignore_job_names.split(","))


### PR DESCRIPTION
We want to support not warning users for every on hold job that's going to be cancelled.

Now, the log job canceller allows us to pass an ignore parameter, and workflows that are paused we examine all the on hold jobs to see if all those jobs contain the ignore word (or words). If so, do not warn the user.