### PR TITLE
Feature: Alerting on exceptions from CCI, and `n-windows` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Alerting included now for errors originating from CircleCI
-- `circleci-continue-long-job-cancel.yml`
+- Command: `circleci-continue-long-job-cancel`
   - `--n-windows` argument:
     - Allows for setting how many windows for the continue CircleCI crawler to walk back across
     - Default: 6 (12 hours, each window is 2 hours in length)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.14] - 2023-01-27
+
+### Added
+- Alerting included now for errors originating from CircleCI
+- `circleci-continue-long-job-cancel.yml`
+  - `--n-windows` argument:
+    - Allows for setting how many windows for the continue CircleCI crawler to walk back across
+    - Default: 6 (12 hours, each window is 2 hours in length)
+
 ## [1.0.13] - 2023-01-23
 
 ### Fixed

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -11,14 +11,17 @@ parameters:
     description: the name of the environmental variable that contains the circleci token
     default: "CIRCLECI_TOKEN"
     type: string
-
+  n-windows:
+    description: Number of windows to look back across. Default window length is 2 hours.
+    default: 6
+    type: integer
 steps:
   - run:
       name: Cancel long jobs
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >>
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/scripts/circleci-job-canceller/Modules/circle_utils.py
+++ b/src/scripts/circleci-job-canceller/Modules/circle_utils.py
@@ -2,12 +2,24 @@ import requests
 import pprint
 
 
+def http_get(url, headers):
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response
+
+
+def http_post(url, headers):
+    response = requests.post(url, headers=headers)
+    response.raise_for_status()
+    return response
+
+
 def get_all_items(relative_url, headers, pagination_limit=5):
     url = f"https://circleci.com/api/v2{relative_url}"
     temp_url = str(url)
     pages_iterated = 0
     while True:
-        res = requests.get(temp_url, headers=headers).json()
+        res = http_get(temp_url, headers=headers).json()
         try:
             # delegates iteration to the (list), so returns 1 by one...
             yield from res["items"]

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -23,7 +23,7 @@ robot_committers = ["apollo-bot2"]
 
 def get_workflow_started_by(current_workflow, headers):
     user_url = f"https://circleci.com/api/v2/user/{current_workflow['started_by']}"
-    user_info = requests.get(user_url, headers=headers).json()
+    user_info = http_get(user_url, headers=headers).json()
     # the Github / CircleCI scheduling bot won't have a username (JSON body will be {'message': 'Not found.'})
     username = user_info.get("login", "")
 
@@ -81,7 +81,7 @@ def main(circleapitoken, orgreposlug, output_file, commit):
                 print(
                     f"found too old workflow: {current_info['id']} ({current_info['name']}) See more info at: https://app.circleci.com/pipelines/workflows/{current_info['id']}")
                 if commit:
-                    requests.post(
+                    http_post(
                         f"https://circleci.com/api/v2/workflow/{current_info['id']}/cancel", headers=standard_headers)
 
             f.write(

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -60,7 +60,7 @@ def find_old_workflow_ids(repo_slug, window_start, window_end, headers):
                     yield {"job_status": "too_old", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
 
 
-def main(circleapitoken, orgreposlug, output_file, commit):
+def main(circleapitoken, orgreposlug, n_windows, output_file, commit):
     standard_headers = {"Circle-Token": circleapitoken}
 
     simple_path = os.path.abspath(os.path.expanduser(
@@ -70,7 +70,7 @@ def main(circleapitoken, orgreposlug, output_file, commit):
         f.write("job_status\tproceed\tid\tusername\tname\n")
         for current_info in find_old_workflow_ids(
             orgreposlug,
-            now - (job_life_clock * 5),
+            now - (job_life_clock * n_windows),
             now - job_midlife_warning,
             standard_headers
         ):
@@ -99,7 +99,9 @@ if __name__ == "__main__":
                         default="/tmp/notifications.tsv", )
     parser.add_argument("--commit", help="just cancel jobs",
                         default=False, action="store_true")
+    parser.add_argument("--n-windows", help="Number of windows to look back across. Default window length is 2 hours.",
+                        default=6, action="store_true")
 
     args = parser.parse_args()
 
-    main(args.circleapitoken, args.orgreposlug, args.output_file, args.commit)
+    main(args.circleapitoken, args.orgreposlug, args.n_windows, args.output_file, args.commit)

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from Modules.circle_utils import *
-import requests
 import datetime
 import sys
 import os.path

--- a/src/scripts/circleci-job-canceller/main_is_borked.py
+++ b/src/scripts/circleci-job-canceller/main_is_borked.py
@@ -12,6 +12,8 @@ import re
 
 from dateutil.parser import *
 
+sys.path.append("..")  # added!
+
 # Turn on / off debugging
 #http.client.HTTPConnection.debuglevel = 1
 

--- a/src/scripts/circleci-job-canceller/main_is_borked.py
+++ b/src/scripts/circleci-job-canceller/main_is_borked.py
@@ -4,8 +4,6 @@ from Modules.circle_utils import *
 
 import argparse
 import pprint
-import json
-import http
 import datetime
 import sys
 import re

--- a/src/scripts/circleci-job-canceller/main_is_borked.py
+++ b/src/scripts/circleci-job-canceller/main_is_borked.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import requests
+from Modules.circle_utils import *
 
 import argparse
 import pprint
@@ -74,7 +74,7 @@ def make_graphql_query(githubtoken, orgreposlug):
 
     graph_ql_verify = {"query": """query { viewer { login } }"""}
 
-    res = requests.post("https://api.github.com/graphql", json=graph_ql_query, headers={
+    res = http_post("https://api.github.com/graphql", json=graph_ql_query, headers={
         "Authorization": f"Bearer {githubtoken}",
         "Content-Type": "application/json"
     })
@@ -134,7 +134,7 @@ def main(githubtoken, orgreposlug, circleapitoken):
                 api_url = f"https://circleci.com/api/v2/workflow/{workflow_id}"
                 standard_headers = {"Circle-Token": circleapitoken}
 
-                workflow_info = requests.get(api_url, headers=standard_headers).json()
+                workflow_info = http_get(api_url, headers=standard_headers).json()
                 if workflow_info.get("status") == "canceled":
                     return
 
@@ -163,10 +163,10 @@ def main(githubtoken, orgreposlug, circleapitoken):
                 standard_headers = {"Circle-Token": circleapitoken}
                 api_url = f"https://circleci.com/api/v2/project/gh/{orgreposlug}/job/{job_id}"
 
-                workflow_info = requests.get(api_url, headers=standard_headers).json()
+                workflow_info = http_get(api_url, headers=standard_headers).json()
                 pipeline_id = workflow_info["pipeline"]["id"]
 
-                pipeline_info = requests.get(f"https://circleci.com/api/v2/pipeline/{pipeline_id}", headers=standard_headers).json()
+                pipeline_info = http_get(f"https://circleci.com/api/v2/pipeline/{pipeline_id}", headers=standard_headers).json()
                 #print(pipeline_info)
 
                 failed_branch = pipeline_info["vcs"]["branch"]


### PR DESCRIPTION
# Motivation

Presently our usage of this 🔮 orb runs, on a cron, to look for Workflows which _should_ be cancelled. However, we disable this:

- At "night"
- Over the "weekend"

With those limitations, the default window we paginate over, 2 hours, doesn't cut the mustard ✂️ 🌭 .

## Notes

This also introduces raising exceptions for non successful HTTP responses. This is something we don't do presently and causes some hidden problems for us.