### PR TITLE
Fix/job caneller not using iso formats for datetime comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.17] - 2023-01-27
+
+### Fixed
+- 1.0.13 introduced a bug with `circleci-continue-long-job-cancel`'s datetime comparisons.
+
 ## [1.0.16] - 2023-01-27
 
 ### Fixed

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -34,7 +34,7 @@ def pipeline_created_at_to_datetime(pipeline):
     Pipeline's create_at value is in ISO 8601 format: Y-m-dTH:M:S.fZ, convert to a
     datetime.
     '''
-    return datetime.datetime.fromisoformat(pipeline['created_at'][:-1])
+    return datetime.datetime.fromisoformat(pipeline['created_at'][:-1]).replace(tzinfo=datetime.timezone.utc)
 
 
 def find_old_workflow_ids(repo_slug, window_start, window_end, headers):


### PR DESCRIPTION
# Motivation

While wrapping up work on #22 noticed that the string comparisons being used in the window checks were only respecting up to the day, not the hours, minutes, etc.

## Notes

[Example from this run:](https://circleci.com/gh/mdg-private/circleci-job-cancel-bot/8224)

```
Window to paginate through: [2023-01-23 21:46:04.380926+00:00, 2023-01-27 20:46:04.380926+00:00]
midlife warning for workflow (kotlin), started by gh:moberegger. See more info at: https://app.circleci.com/pipelines/workflows/4ecc89d9-1afc-4ced-93f5-fc8932c271be
midlife warning for workflow (kotlin), started by gh:krachwal. See more info at: https://app.circleci.com/pipelines/workflows/a0075755-7bde-4667-a5ca-acf278a65ffe
found too old workflow: f5397154-205e-447c-8bbf-49007ad96e94 (kotlin) See more info at: https://app.circleci.com/pipelines/workflows/f5397154-205e-447c-8bbf-49007ad96e94
found too old workflow: e551e722-434b-4c1b-8709-cd652eed6e1a (kotlin) See more info at: https://app.circleci.com/pipelines/workflows/e551e722-434b-4c1b-8709-cd652eed6e1a
midlife warning for workflow (kotlin), started by gh:cy. See more info at: https://app.circleci.com/pipelines/workflows/b5ace7e1-3a47-4856-932e-f2a87a9d3536
Pipeline too old: 2023-01-23 21:43:22.928000+00:00
```

Notice the `Pipeline too old: 2023-01-23 21:43:22.928000+00:00` timestamp is now matching the format present in `Window to paginate through: [2023-01-23 21:46:04.380926+00:00, 2023-01-27 20:46:04.380926+00:00]`