### PR TITLE
make slack-compact even more compact; setup is idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.18] - 2023-02-03
+### Fixed
+  - further reduce the size of code generated during slack-notify-compact command
+  - setup command only downloads repository once
+
 ## [1.0.17] - 2023-01-27
 
 ### Fixed

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -10,7 +10,7 @@ steps:
   - run:
       when: always
       command: |
-        if [ -d  /tmp/apollo_internal_platform_orb ];
+        if [ ! -e  /tmp/apollo_internal_platform_orb ];
         then
           curl -L --output /tmp/source.tar.gz "https://api.github.com/repos/apollographql/internal-platform-orb/tarball/<< parameters.download-reference >>"
           mkdir -p /tmp/apollo_internal_platform_orb

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -8,6 +8,7 @@ parameters:
 
 steps:
   - run:
+      when: always
       command: |
         if [ -d  /tmp/apollo_internal_platform_orb ];
         then

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -9,8 +9,11 @@ parameters:
 steps:
   - run:
       command: |
-        curl -L --output /tmp/source.tar.gz "https://api.github.com/repos/apollographql/internal-platform-orb/tarball/<< parameters.download-reference >>"
-        mkdir -p /tmp/apollo_internal_platform_orb
-        tar -xzvf /tmp/source.tar.gz -C /tmp/apollo_internal_platform_orb --strip-components=1
+        if [ -d  /tmp/apollo_internal_platform_orb ];
+        then
+          curl -L --output /tmp/source.tar.gz "https://api.github.com/repos/apollographql/internal-platform-orb/tarball/<< parameters.download-reference >>"
+          mkdir -p /tmp/apollo_internal_platform_orb
+          tar -xzvf /tmp/source.tar.gz -C /tmp/apollo_internal_platform_orb --strip-components=1
+        fi
   - store_artifacts:
      path: /tmp/apollo_internal_platform_orb

--- a/src/commands/slack-notify-compact.yml
+++ b/src/commands/slack-notify-compact.yml
@@ -42,8 +42,7 @@ steps:
       name: Slack - Detecting Job Status (PASS)
       command: |
         echo 'export CCI_STATUS="pass"' > /tmp/SLACK_JOB_STATUS
-  - setup:
-      when: always
+  - setup
   - run:
       when: always
       name: Slack - Sending Notification

--- a/src/commands/slack-notify-compact.yml
+++ b/src/commands/slack-notify-compact.yml
@@ -42,6 +42,8 @@ steps:
       name: Slack - Detecting Job Status (PASS)
       command: |
         echo 'export CCI_STATUS="pass"' > /tmp/SLACK_JOB_STATUS
+  - setup:
+      when: always
   - run:
       when: always
       name: Slack - Sending Notification
@@ -49,4 +51,4 @@ steps:
         SLACK_PARAM_EVENT: "<<parameters.event>>"
         SLACK_PARAM_CHANNEL: "<<parameters.channel>>"
         SLACK_PARAM_CUSTOM: "<<parameters.custom>>"
-      command: <<include(scripts/alert-slack-notify.sh)>>
+      command: bash /tmp/apollo_internal_platform_orb/src/scripts/alert-slack-notify.sh


### PR DESCRIPTION
# Motivation

We yet again ran into the scenario where our compiled configs are too large. One way we can further reduce our size is to call the Slack script externally, vs compiling it into the CircleCI config.

This change, in _addition_ to some changes we made internally, was able to bring the configuration size down into allowable size