### PR TITLE
Fix: get_workflow_started_by Github Bot users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2023-02-06
+### Fixed
+- 1.0.13 introduced a bug with `circleci-continue-long-job-cancel`'s ability to correctly fetch user
+  info for better Slack messages.
+
 ## [1.0.18] - 2023-02-03
 ### Fixed
   - further reduce the size of code generated during slack-notify-compact command

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -21,12 +21,18 @@ robot_committers = ["apollo-bot2"]
 
 
 def get_workflow_started_by(current_workflow, headers):
-    user_url = f"https://circleci.com/api/v2/user/{current_workflow['started_by']}"
-    user_info = http_get(user_url, headers=headers).json()
-    # the Github / CircleCI scheduling bot won't have a username (JSON body will be {'message': 'Not found.'})
-    username = user_info.get("login", "")
+    user_url = f'https://circleci.com/api/v2/user/{current_workflow["started_by"]}'
 
-    return username
+    try:
+        user_info = http_get(user_url, headers=headers).json()
+        return user_info.get("login")
+    except requests.exceptions.HTTPError as e:
+        print(
+            f'Exception encountered fetching user: {current_workflow["started_by"]} for current_workflow: {current_workflow["id"]}: {e}'
+        )
+        # 4XX
+        # the Github / CircleCI scheduling bot won't have a username (JSON body will be {'message': 'Not found.'})
+        return ''
 
 
 def pipeline_created_at_to_datetime(pipeline):


### PR DESCRIPTION
# Motivation

Seeing failures for Github Bots: `404 Client Error: Not Found for url: https://circleci.com/api/v2/user/<redacted>`

```
Traceback (most recent call last):
  File "/tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller/long_job_canceller.py", line 120, in <module>
    main(args.circleapitoken, args.orgreposlug,
  File "/tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller/long_job_canceller.py", line 79, in main
    for current_info in find_old_workflow_ids(
  File "/tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller/long_job_canceller.py", line 66, in find_old_workflow_ids
    username = get_workflow_started_by(
  File "/tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller/long_job_canceller.py", line 25, in get_workflow_started_by
    user_info = http_get(user_url, headers=headers).json()
  File "/tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller/Modules/circle_utils.py", line 7, in http_get
    response.raise_for_status()
  File "/home/circleci/.pyenv/versions/3.10.4/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://circleci.com/api/v2/user/<redacted>

Exited with code exit status 1
```