### PR TITLE
Migrate security scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2023-02-07
+### Added
+- Added jobs/commands/executors and associated examples to run the following security scanning tools:
+  - wiz infrastructure-as-code and wiz docker 
+  - gitleaks
+  - semgrep
+  - osv-scanner
+
 ## [1.0.18] - 2023-02-03
 ### Fixed
   - further reduce the size of code generated during slack-notify-compact command

--- a/src/commands/gitleaks-check-local.yml
+++ b/src/commands/gitleaks-check-local.yml
@@ -1,0 +1,56 @@
+description: |
+  Run Gitleaks against a local repository.
+
+parameters:
+  path:
+    type: string
+    description: Path to local Git repository
+    default: ${CIRCLE_WORKING_DIRECTORY}
+  options:
+    type: string
+    description: Additional options to pass to the Gitleaks CLI
+    default: ''
+  git-base-revision:
+    type: string
+    description: The commit hash of the earliest commit to be scanned
+  git-revision:
+    type: string
+    description: The commit hash of the latest commit to be scanned
+
+steps:
+  - run:
+      name: Decide which commits to check
+      command: |
+        DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | cut -c8-)
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        echo "I detected that the default branch is ${DEFAULT_BRANCH}"
+        echo "I detected that the current branch is ${CURRENT_BRANCH}"
+        if [ $DEFAULT_BRANCH = $CURRENT_BRANCH ]
+        then
+          echo "Looks like we're in the repo's default branch."
+          echo "I'm going to validate all commits since the last CircleCI run"
+          COMMIT_COUNT=$(git rev-list --count << parameters.git-base-revision >>..<< parameters.git-revision >> )
+          if [ $COMMIT_COUNT -eq 1 ]
+          then
+            echo "-1" > /tmp/logopts.txt
+          else
+            echo "--first-parent << parameters.git-base-revision >>^..<< parameters.git-revision >>" > /tmp/logopts.txt
+          fi
+        else
+          echo "Looks like we're not in the default branch"
+          echo "I'm going to validate all commits in this branch"
+          echo "This will prevent merging secrets into the main branch"
+          FIRST_COMMIT=$(git log $(git merge-base ${DEFAULT_BRANCH} ${CURRENT_BRANCH})..HEAD --pretty=format:%H | tail -n 1)
+          echo "--first-parent ${FIRST_COMMIT}^..<< parameters.git-revision >>" > /tmp/logopts.txt
+
+          if grep -Eq '^--first-parent \^' /tmp/logopts.txt;
+          then
+            echo "-1" > /tmp/logopts.txt
+          fi
+        fi
+        echo "git log options created:"
+        echo "$(cat /tmp/logopts.txt)"
+  - run:
+      name: Check repository for secrets
+      command: |
+        gitleaks --source=<< parameters.path >> detect --config=/app/.gitleaks/custom-config.toml --log-opts="$(cat /tmp/logopts.txt)" --redact --verbose --log-level=debug --exit-code=1 << parameters.options >>

--- a/src/commands/osvscan-check-local.yml
+++ b/src/commands/osvscan-check-local.yml
@@ -1,0 +1,47 @@
+description: |
+  Run osv-scanner against a local repository.
+
+  osv-scanner checks for vulnerabilities in dependencies by comparing package versions in lockfiles
+  to vulnerability databases. This job reports on those findings and additionally checks for related,
+  existing pull requests in Github that appear to resolve the identified vulnerability.
+
+  osv-scanner will recursively search for the following lockfiles to scan for vulnerabilities:
+  buildscript-gradle.lockfile, Cargo.lock, composer.lock, conan.lock, Gemfile.lock, go.mod, gradle.lockfile,
+  mix.lock, package-lock.json, packages.lock.json, Pipfile.lock, pnpm-lock.yaml, poetry.lock, pom.xml,
+  pubspec.lock, requirements.txt, and yarn.lock. Additional lockfile formats may be added in the future.
+  See https://github.com/google/osv-scanner#input-a-lockfile for the most up-to-date list.
+
+  By default, this job will fail builds if 1 or more critical-severity vulnerabilities is identified
+  in lockfiles. This behavior can be overridden via the fail-on-findings and min-fail-severity
+  parameters.
+
+parameters:
+  path:
+    type: string
+    description: Path to local Git repository
+    default: ${CIRCLE_WORKING_DIRECTORY}
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  min-fail-severity:
+    type: enum
+    enum: ['LOW', 'MODERATE', 'HIGH', 'CRITICAL']
+    description: The minimum severity of finding that will cause builds to fail.
+    default: CRITICAL
+
+
+steps:
+  - run:
+      name: Handle Selected Options
+      command: |
+        echo "export OSV_SOURCE_PATH=<< parameters.path >>" >> "$BASH_ENV"
+        echo "export OSV_FAIL_BUILDS=<< parameters.fail-on-findings >>" >> "$BASH_ENV"
+        echo "export OSV_FAIL_SEVERITY=<< parameters.min-fail-severity >>" >> "$BASH_ENV"
+  - run:
+      name: Run Scan
+      command: |
+         python3 /app/run-scan.py
+  - store_artifacts:
+      path: /tmp/osv-scan.json
+      destination: scan-results/osv-scan.json

--- a/src/commands/semgrep-check-local.yml
+++ b/src/commands/semgrep-check-local.yml
@@ -1,0 +1,129 @@
+description: |
+  Run Semgrep against a local repository.
+
+  Semgrep supports scanning all of the common languages in use at Apollo including Kotlin, Java, Typescript, Javascript, Rust, Python, etc.
+  See https://semgrep.dev/docs/supported-languages/ for the list of all supported languages. Languages labelled "Beta" or "Experimental"
+  on the linked page are supported. The differences between these support levels are mainly in the number of semgrep-internal features currently
+  supported for the language and the number of open-source rules available for the language.
+
+  This command will not break builds if an unsupported language is present in the repo being scanned. Rulesets are enabled based on
+  the files in the repository and rules are only executed on files that contain code in supported languages.
+
+  The rules Semgrep executes are versioned here: https://github.com/mdg-private/semgrep-scan/tree/main/rules. SecOps regularly
+  fetches new rules from open-source respositories of high-quality Semgrep rules. Apollo engineers are encouraged to open PRs on the
+  linked repo to contribute new rules as desired.
+
+parameters:
+  path:
+    type: string
+    description: Path to local Git repository
+    default: ${CIRCLE_WORKING_DIRECTORY}
+  options:
+    type: string
+    description: Additional options to pass to the Semgrep CLI
+    default: ''
+  git-base-revision:
+    type: string
+    description: The commit hash of the earliest commit to be scanned
+  run-security-checks:
+    type: boolean
+    description: If true, add security rules to list of checks that semgrep performs
+    default: true
+  run-bestpractice-checks:
+    type: boolean
+    description: If true, add best practice / code-style rules to the list of checks that semgrep performs
+    default: false
+  disabled-signatures:
+    type: string
+    description: A comma-separated list of signatures that you would like to disable
+    default: ''
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  min-fail-severity:
+    type: enum
+    enum: ['INFO', 'WARNING', 'ERROR']
+    description: The minimum severity of finding that will cause builds to fail.
+    default: ERROR
+  do-diff-scan:
+    type: boolean
+    description: Set to False if you want to scan all files in the repo, not just changed files.
+    default: true
+  update-rules:
+    type: boolean
+    description: |
+      Set to true if rules should be updated prior to scanning. Else, scanning uses the rules built into the executor.
+      Rules are updated from https://github.com/mdg-private/semgrep-scan/tree/main/rules
+    default: true
+
+
+steps:
+  - run:
+      name: Decide which commits to check
+      command: |
+        DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | cut -c8-)
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        echo "I detected that the default branch is: ${DEFAULT_BRANCH}"
+        echo "I detected that the current branch is: ${CURRENT_BRANCH}"
+        if [ $DEFAULT_BRANCH = $CURRENT_BRANCH ]
+        then
+          echo "Looks like we're in the repo's default branch."
+          echo "I'm going to validate all commits since the last CircleCI run"
+          echo "--baseline-commit << parameters.git-base-revision >>" > /tmp/logopts.txt
+
+        else
+          echo "Looks like we're not in the default branch"
+          echo "I'm going to validate all commits in this branch"
+          FIRST_COMMIT=$(git log $(git merge-base ${DEFAULT_BRANCH} ${CURRENT_BRANCH})..HEAD --pretty=format:%H | tail -n 1)
+          echo "--baseline-commit ${FIRST_COMMIT}" > /tmp/logopts.txt
+
+          if grep -Eq '^--baseline-commit $' /tmp/logopts.txt;
+          then
+            echo "--baseline-commit $(git merge-base ${DEFAULT_BRANCH} ${CURRENT_BRANCH})" > /tmp/logopts.txt
+          fi
+        fi
+        echo "The baseline-commit argument generated is: $(cat /tmp/logopts.txt)"
+  - run:
+      name: Handle Selected Options
+      command: |
+        echo "export SEMGREP_SECURITY_TESTS=<< parameters.run-security-checks >>" >> "$BASH_ENV"
+        echo "export SEMGREP_BESTPRACTICE_TESTS=<< parameters.run-bestpractice-checks >>" >> "$BASH_ENV"
+        echo "export SEMGREP_DISABLED_RULES=<< parameters.disabled-signatures >>" >> "$BASH_ENV"
+        echo "export SEMGREP_SOURCE_PATH=<< parameters.path >>" >> "$BASH_ENV"
+        echo "export FAIL_ON_FINDINGS=<< parameters.fail-on-findings >>" >> "$BASH_ENV"
+        echo "export MIN_FAIL_SEVERITY=<< parameters.min-fail-severity >>" >> "$BASH_ENV"
+        echo "export SEMGREP_DIFF_SCAN=<< parameters.do-diff-scan >>" >> "$BASH_ENV"
+        echo "export UPDATE_RULES=<< parameters.update-rules >>" >> "$BASH_ENV"
+  - run:
+      name: Update Rules
+      command: |
+        if $UPDATE_RULES;
+        then
+          echo $GH_BOT_KEY_B64 | base64 -d > ~/.ssh/apollobot
+          git clone https://apollo-bot2:$(cat ~/.ssh/apollobot)@github.com/mdg-private/semgrep-scan /tmp/semgrep-scan
+          rm -rf /rules/*
+          rm -f ~/.ssh/apollobot
+          mv /tmp/semgrep-scan/rules/* /rules
+          cd /tmp/semgrep-scan
+          echo "Rules Updated to commit $(git rev-parse HEAD)"
+          echo "You can view these rules at: https://github.com/mdg-private/semgrep-scan/tree/$(git rev-parse HEAD)/rules"
+          cd /app
+        fi
+  - run:
+      name: Build Semgrep command
+      command: |
+        python3 /app/build-args.py
+        echo "Semgrep will be run with the following args:"
+        echo "$(cat /tmp/semgrepopts.txt) << parameters.options >>"
+  - run:
+      name: Run Semgrep
+      command: |
+         semgrep scan $(cat /tmp/semgrepopts.txt) << parameters.options >> << parameters.path >>
+  - store_artifacts:
+      path: /tmp/semgrep.json
+      destination: scan-results/semgrep.json
+  - run:
+      name: Results
+      command: |
+        python3 /app/handle-output.py

--- a/src/commands/wiz-docker-check-local.yml
+++ b/src/commands/wiz-docker-check-local.yml
@@ -1,0 +1,30 @@
+description: |
+  Test docker containers against SecOps-defined rules for misconfigurations.
+
+parameters:
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  workspace-dir:
+    type: string
+    description: The path in the executor where the workspace is mounted.
+  wiz-policies:
+    type: string
+    description: One or more Wiz IAC policies to use during this scan. If specifying multiple, they should be comma-separated
+    default: Apollo-Default-Vulnerabilities-Policy
+
+steps:
+  - run:
+      name: Handle Selected Options
+      command: |
+        echo "export WIZ_POLICIES='<< parameters.wiz-policies >>'" >> "$BASH_ENV"
+        echo "export WORKSPACE_DIR=<< parameters.workspace-dir >>" >> "$BASH_ENV"
+        echo "export WIZ_FAIL_BUILDS=<< parameters.fail-on-findings >>" >> "$BASH_ENV"
+  - run:
+      name: Run Wiz Container Scan
+      command: |
+         python3 /app/run-docker-scan.py
+  - store_artifacts:
+      path: /tmp/wiz-docker.json
+      destination: scan-results/wiz-docker.json

--- a/src/commands/wiz-iac-check-local.yml
+++ b/src/commands/wiz-iac-check-local.yml
@@ -1,0 +1,36 @@
+description: |
+  Test infrastructure-as-code against SecOps-defined rules for misconfigurations.
+
+parameters:
+  path:
+    type: string
+    description: Path to local Git repository
+    default: ${CIRCLE_WORKING_DIRECTORY}
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  do-diff-scan:
+    type: boolean
+    description: Set to False if you want to scan all files in the repo, not just changed files.
+    default: true
+  wiz-policies:
+    type: string
+    description: One or more Wiz IAC policies to use during this scan. If specifying multiple, they should be comma-separated
+    default: Apollo-Default-IAC-Policy
+
+steps:
+  - run:
+      name: Handle Selected Options
+      command: |
+        echo "export WIZ_DIFF_SCAN=<< parameters.do-diff-scan >>" >> "$BASH_ENV"
+        echo "export WIZ_SOURCE_PATH=<< parameters.path >>" >> "$BASH_ENV"
+        echo "export WIZ_POLICIES='<< parameters.wiz-policies >>'" >> "$BASH_ENV"
+        echo "export WIZ_FAIL_BUILDS=<< parameters.fail-on-findings >>" >> "$BASH_ENV"
+  - run:
+      name: Run Wiz IAC Scan
+      command: |
+         python3 /app/run-iac-scan.py
+  - store_artifacts:
+      path: /tmp/wiz-iac.json
+      destination: scan-results/wiz-iac.json

--- a/src/examples/using-gitleaks.yml
+++ b/src/examples/using-gitleaks.yml
@@ -1,0 +1,15 @@
+description: >
+  An example of using gitleaks in your workflow to test code for secrets
+usage:
+  version: 2.1
+  orbs:
+    circleci-pde-orb: apollo-mdg-private/circleci-pde-orb@2.0.7
+  workflows:
+    check-for-secrets:
+      jobs:
+        - circleci-pde-orb/gitleaks:
+            # This is ugly but currently required. CircleCI doesn't always set this parameter. This handles cases where it doesn't exist.
+            git-base-revision: <<#pipeline.git.base_revision >><<pipeline.git.base_revision >><</pipeline.git.base_revision >>
+            git-revision: << pipeline.git.revision >>
+            context:
+              - platform-docker-ro

--- a/src/examples/using-osvscan.yml
+++ b/src/examples/using-osvscan.yml
@@ -1,0 +1,28 @@
+description: >
+  An example of using osv-scanner in your pipelines to check for vulnerabilities in dependencies.
+
+  osv-scanner checks for vulnerabilities in dependencies by comparing package versions in lockfiles
+  to vulnerability databases. This job reports on those findings and additionally checks for related,
+  existing pull requests in Github that appear to resolve the identified vulnerability.
+
+  osv-scanner will recursively search for the following lockfiles to scan for vulnerabilities:
+  buildscript-gradle.lockfile, Cargo.lock, composer.lock, conan.lock, Gemfile.lock, go.mod, gradle.lockfile,
+  mix.lock, package-lock.json, packages.lock.json, Pipfile.lock, pnpm-lock.yaml, poetry.lock, pom.xml,
+  pubspec.lock, requirements.txt, and yarn.lock. Additional lockfile formats may be added in the future.
+  See https://github.com/google/osv-scanner#input-a-lockfile for the most up-to-date list.
+
+  By default, this job will fail builds if 1 or more critical-severity vulnerabilities is identified
+  in lockfiles. This behavior can be overridden via the fail-on-findings and min-fail-severity
+  parameters.
+
+usage:
+  version: 2.1
+  orbs:
+    circleci-pde-orb: apollo-mdg-private/circleci-pde-orb@2.0.11
+  workflows:
+    check-for-vulns:
+      jobs:
+        - circleci-pde-orb/osvscan:
+            context:
+              - platform-docker-ro
+              - github-orb

--- a/src/examples/using-semgrep.yml
+++ b/src/examples/using-semgrep.yml
@@ -1,0 +1,29 @@
+description: >
+  An example of using semgrep in your workflow to test code for vulnerabilities.
+
+  Semgrep supports scanning all of the common languages in use at Apollo including Kotlin, Java, Typescript, Javascript, Rust, Python, etc.
+  See https://semgrep.dev/docs/supported-languages/ for the list of all supported languages. Languages labelled "Beta" or "Experimental"
+  on the linked page are supported. The differences between these support levels are mainly in the number of semgrep-internal features currently
+  supported for the language and the number of open-source rules available for the language.
+
+  This job will not break builds if an unsupported language is present in the repo being scanned. Rulesets are enabled based on
+  the files in the repository and rules are only executed on files that contain code in supported languages.
+
+  The rules Semgrep executes are versioned here: https://github.com/mdg-private/semgrep-scan/tree/main/rules. SecOps regularly
+  fetches new rules from open-source respositories of high-quality Semgrep rules. Apollo engineers are encouraged to open PRs on the
+  linked repo to contribute new rules as desired. Rules can also be written for non-security usecases like enforcing best practice and code style.
+
+usage:
+  version: 2.1
+  orbs:
+    circleci-pde-orb: apollo-mdg-private/circleci-pde-orb@2.0.8
+  workflows:
+    check-for-vulns:
+      jobs:
+        - circleci-pde-orb/semgrep:
+            # This is ugly but currently required. CircleCI doesn't always set this parameter. This handles cases where it doesn't exist.
+            git-base-revision: <<#pipeline.git.base_revision >><<pipeline.git.base_revision >><</pipeline.git.base_revision >>
+            git-revision: << pipeline.git.revision >>
+            context:
+              - platform-docker-ro
+              - github_orb

--- a/src/examples/using-wiz-docker.yml
+++ b/src/examples/using-wiz-docker.yml
@@ -1,0 +1,57 @@
+description: >
+  An example of using Wiz Docker scanning in your pipeline to check for vulnerabilities.
+
+  Wiz is a security tool owned by the SecOps team to monitor for vulnerabilities, misconfigurations, errors, and incidents
+  occurring in Apollo's public cloud environments.
+
+  Wiz provides the ability to scan built Docker containers for vulnerabilities. Use this job to assess containers
+  as you're building them in your pipeline to ensure the container doesn't contain critical vulnerabilities that should
+  be fixed before the container is used in production.
+
+  Note that this job relies on your container being built already. You will need to tell CircleCI about
+  this dependency via the 'requires' keyword.
+
+  To pass the built container into this orb, you will need to use CircleCI workspaces. This job will scan a tar file containing
+  a docker image saved to <workspace>/container/<name>.tar. This directory should contain exactly one tar.
+
+  A simple example of building the container, saving it to a tar file, exporting it to a workspace, and scanning the container
+  is provided below.
+
+usage:
+  version: 2.1
+  orbs:
+    circleci-pde-orb: apollo-mdg-private/circleci-pde-orb@2.0.9
+  workflows:
+    build-and-scan-container:
+      jobs:
+        - run:
+            name: Set up Workspace directory
+            command:
+              mkdir -p /tmp/workspace/container
+        - run:
+            name: Make a Docker Tag
+            command: |
+              echo "$(date +%Y).$(date +%m).b$CIRCLE_BUILD_NUM" > stable_build_number.txt
+        - run:
+            name: Build Container
+            command: |
+              export IMAGE_TAG=$(cat stable_build_number.txt)
+              docker build \
+                -t registry/MY_CONTAINER_NAME:$IMAGE_TAG \
+                -f Dockerfile .
+        - run:
+            name: Save Container for Analysis
+            command: |
+              export IMAGE_TAG=$(cat stable_build_number.txt)
+              docker save -o /tmp/workspace/container/MY_CONTAINER_NAME.tar \
+                registry/MY_CONTAINER_NAME:$IMAGE_TAG
+        - persist_to_workspace:
+            root: /tmp/workspace
+            paths:
+              - container/MY_CONTAINER_NAME.tar
+        - circleci-pde-orb/wiz-docker:
+            context:
+              - platform-docker-ro
+              - wiz
+            requires:
+              - "Build Container"

--- a/src/examples/using-wiz-iac.yml
+++ b/src/examples/using-wiz-iac.yml
@@ -1,0 +1,22 @@
+description: >
+  An example of using Wiz Infrastructure-as-Code (IAC) scanning in your pipeline to check for vulnerabilities.
+
+  Wiz is a security tool owned by the SecOps team to monitor for vulnerabilities, misconfigurations, errors, and incidents
+  occurring in Apollo's public cloud environments.
+
+  Wiz provides the ability to scan IAC files like terraform documents, dockerfiles, etc. to identify vulnerabilities
+  that will be introduced if the IAC file is executed. Use this job to prevent vulnerabilities from being introduced
+  via IAC.
+
+usage:
+  version: 2.1
+  orbs:
+    circleci-pde-orb: apollo-mdg-private/circleci-pde-orb@2.0.9
+  workflows:
+    security-scans:
+      jobs:
+        - circleci-pde-orb/wiz-iac:
+            context:
+              - platform-docker-ro
+              - github_orb
+              - wiz

--- a/src/executors/gitleaks-ci.yml
+++ b/src/executors/gitleaks-ci.yml
@@ -1,0 +1,12 @@
+description: |
+  Use containerized Gitleaks to check the repository for secrets.
+
+docker:
+- image: us-central1-docker.pkg.dev/platform-cross-environment/platform-docker/gitleaks-minimal:2022.12.b29
+  auth:
+    username: _json_key
+    # This requires usage of one of the platform-docker-[ro] contexts
+    password: $CONTAINER_READONLY
+resource_class: small
+environment:
+  GOOGLE_CREDENTIALS: /tmp/.appcreds.json

--- a/src/executors/osvscan-ci.yml
+++ b/src/executors/osvscan-ci.yml
@@ -1,0 +1,12 @@
+description: |
+  Use containerized osv-scan to check the repository for vulnerabilities.
+
+docker:
+- image: us-central1-docker.pkg.dev/platform-cross-environment/platform-docker/osvscan-ci:2023.01.b196
+  auth:
+    username: _json_key
+    # This requires usage of one of the platform-docker-[ro] contexts
+    password: $CONTAINER_READONLY
+resource_class: medium
+environment:
+  GOOGLE_CREDENTIALS: /tmp/.appcreds.json

--- a/src/executors/semgrep-ci.yml
+++ b/src/executors/semgrep-ci.yml
@@ -1,0 +1,12 @@
+description: |
+  Use containerized Semgrep to check the repository for vulnerabilities.
+
+docker:
+- image: us-central1-docker.pkg.dev/platform-cross-environment/platform-docker/semgrep-ci:2023.01.b47
+  auth:
+    username: _json_key
+    # This requires usage of one of the platform-docker-[ro] contexts
+    password: $CONTAINER_READONLY
+resource_class: medium
+environment:
+  GOOGLE_CREDENTIALS: /tmp/.appcreds.json

--- a/src/executors/wiz-ci.yml
+++ b/src/executors/wiz-ci.yml
@@ -1,0 +1,12 @@
+description: |
+  Use containerized wizcli to check the repository for vulnerabilities.
+
+docker:
+- image: us-central1-docker.pkg.dev/platform-cross-environment/platform-docker/wiz-ci:2023.01.b250
+  auth:
+    username: _json_key
+    # This requires usage of one of the platform-docker-[ro] contexts
+    password: $CONTAINER_READONLY
+resource_class: small
+environment:
+  GOOGLE_CREDENTIALS: /tmp/.appcreds.json

--- a/src/jobs/gitleaks.yml
+++ b/src/jobs/gitleaks.yml
@@ -1,0 +1,30 @@
+description: |
+  Clone a Git repo and check it for secrets.
+
+parameters:
+  options:
+    type: string
+    description: Additional options to pass to the Gitleaks CLI
+    default: ''
+  git-base-revision:
+    type: string
+    description: The commit hash of the earliest commit to be scanned. Use this field to pass in CircleCI's pipeline.git.base_revision parameter if it exists.
+  git-default-base-revision:
+    type: string
+    description: The commit hash of the earliest commit to be scanned. Use this field to pass in a fallback if CircleCI's pipeline.git.base_revision parameter doesn't exist.
+    default: HEAD~1
+  git-revision:
+    type: string
+    description: The commit hash of the latest commit to be scanned
+
+executor:
+  name: gitleaks-ci
+
+working_directory: /tmp/project
+
+steps:
+  - checkout
+  - gitleaks-check-local:
+      options: << parameters.options >>
+      git-base-revision: <<#parameters.git-base-revision >><< parameters.git-base-revision >><</parameters.git-base-revision >><<^parameters.git-base-revision >><< parameters.git-default-base-revision >><</parameters.git-base-revision >>
+      git-revision: << parameters.git-revision >>

--- a/src/jobs/osvscan.yml
+++ b/src/jobs/osvscan.yml
@@ -1,0 +1,38 @@
+description: |
+  Check application dependencies for vulnerabilities
+
+  osv-scanner checks for vulnerabilities in dependencies by comparing package versions in lockfiles
+  to vulnerability databases. This job reports on those findings and additionally checks for related,
+  existing pull requests in Github that appear to resolve the identified vulnerability.
+
+  osv-scanner will recursively search for the following lockfiles to scan for vulnerabilities:
+  buildscript-gradle.lockfile, Cargo.lock, composer.lock, conan.lock, Gemfile.lock, go.mod, gradle.lockfile,
+  mix.lock, package-lock.json, packages.lock.json, Pipfile.lock, pnpm-lock.yaml, poetry.lock, pom.xml,
+  pubspec.lock, requirements.txt, and yarn.lock. Additional lockfile formats may be added in the future.
+  See https://github.com/google/osv-scanner#input-a-lockfile for the most up-to-date list.
+
+  By default, this job will fail builds if 1 or more critical-severity vulnerabilities is identified
+  in lockfiles. This behavior can be overridden via the fail-on-findings and min-fail-severity
+  parameters.
+
+parameters:
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  min-fail-severity:
+    type: enum
+    enum: ['LOW', 'MODERATE', 'HIGH', 'CRITICAL']
+    description: The minimum severity of finding that will cause builds to fail.
+    default: CRITICAL
+
+executor:
+  name: osvscan-ci
+
+working_directory: /tmp/project
+
+steps:
+  - checkout
+  - osvscan-check-local:
+      fail-on-findings: << parameters.fail-on-findings >>
+      min-fail-severity: << parameters.min-fail-severity >>

--- a/src/jobs/semgrep.yml
+++ b/src/jobs/semgrep.yml
@@ -1,0 +1,105 @@
+description: |
+  Perform security and (optionally) best-practice tests on source.
+
+  Semgrep supports scanning all of the common languages in use at Apollo including Kotlin, Java, Typescript, Javascript, Rust, Python, etc.
+  See https://semgrep.dev/docs/supported-languages/ for the list of all supported languages. Languages labelled "Beta" or "Experimental"
+  on the linked page are supported. The differences between these support levels are mainly in the number of semgrep-internal features currently
+  supported for the language and the number of open-source rules available for the language.
+
+  This job will not break builds if an unsupported language is present in the repo being scanned. Rulesets are enabled based on
+  the files in the repository and rules are only executed on files that contain code in supported languages.
+
+  The rules Semgrep executes are versioned here: https://github.com/mdg-private/semgrep-scan/tree/main/rules. SecOps regularly
+  fetches new rules from open-source respositories of high-quality Semgrep rules. Apollo engineers are encouraged to open PRs on the
+  linked repo to contribute new rules as desired.
+
+  The default values for the parameters on this job represent SecOps' recommended configuration for long-term
+  implementation in pipelines and for new projects utilizing this job from the start. If you use the default options for
+  all non-required parameters, this job will run security tests for the languages identified in the repo being scanned. Languages
+  present are identified via a combination of filenames and file extensions in the repo. By default this job will operate in a 'diff-aware'
+  mode which only scans files modified via the commit(s) in a given branch. By default, this job will fail builds if a
+  finding with severity "ERROR" (read: critical) is found. The combination of these defaults means that jobs will fail if an ERROR-level finding
+  is introduced in any branch implementing the default values for this check. Pre-existing issues will not be identified or fail builds provided
+  they exist in files not being modified in the branch.
+
+  The goal of the default behavior is to help engineers identify issues early before they are deployed - even to Dev environments. Security
+  vulnerabilities are generally cheaper and easier to fix the earlier they are found.
+
+  This is *strongly* discouraged, but in the event that a team MUST deploy code that contains a vulnerability blocking builds, teams have several options
+  to silence this job without removing it from their pipeline. Teams can add comments to lines introducing the vulnerability to indicate Semgrep should ignore
+  the line (details documented here: https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing).
+  Teams can additionally utilize the 'disabled-signatures' parameter on this job to turn specific rules off in the pipeline. The value(s) that need to be
+  added to this parameter are displayed in both output formats described below. Signatures will usually start with 'rules.providers.semgrep'
+
+  SecOps recommends that teams do not use the default configuration for their initial addition of this job into existing repos. SecOps recommends
+  that initial integration sets 'fail-on-findings' and 'do-diff-scan' to 'false'. Setting fail-on-findings to false will prevent this job from
+  failing builds. Setting do-diff-scan to false will run Semgrep against all files in the repo, not just files being changed. This combination of settings
+  will let teams see all findings that _could_ be generated from the repo while ensuring that builds will not fail. As teams address ERROR-level findings
+  on the repo, they can ratchet the configurations back toward default.
+
+  Output from this job is written to two locations. For a tabular view of results, see the 'Results' step of this job. If teams utilize
+  SecOps' recommended initial deployment configuration for existing repos above, they can see which findings _would_ have failed the build but didn't
+  due to fail-on-findings being set to false in the tabular view. A JSON-formatted report of all findings is also uploaded to the
+  scan-results/semgrep.json build artifact.
+
+parameters:
+  options:
+    type: string
+    description: Additional options to pass to the Semgrep CLI
+    default: ''
+  git-base-revision:
+    type: string
+    description: The commit hash of the earliest commit to be scanned. Use this field to pass in CircleCI's pipeline.git.base_revision parameter if it exists.
+  git-default-base-revision:
+    type: string
+    description: The commit hash of the earliest commit to be scanned. Use this field to pass in a fallback if CircleCI's pipeline.git.base_revision parameter doesn't exist.
+    default: HEAD~1
+  run-security-checks:
+    type: boolean
+    description: If true, add security rules to list of checks that semgrep performs
+    default: true
+  run-bestpractice-checks:
+    type: boolean
+    description: If true, add best practice / code-style rules to the list of checks that semgrep performs
+    default: false
+  disabled-signatures:
+    type: string
+    description: A comma-separated list of rules that you would like to disable
+    default: ''
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  min-fail-severity:
+    type: 'enum'
+    enum: ['INFO', 'WARNING', 'ERROR']
+    description: The minimum severity of finding that will cause builds to fail.
+    default: ERROR
+  do-diff-scan:
+    type: boolean
+    description: Set to False if you want to scan all files in the repo, not just changed files.
+    default: true
+  update-rules:
+    type: boolean
+    description: |
+      Set to true if rules should be updated prior to scanning. Else, scanning uses the rules built into the executor.
+      Rules are updated from https://github.com/mdg-private/semgrep-scan/tree/main/rules
+    default: true
+
+executor:
+  name: semgrep-ci
+
+working_directory: /tmp/project
+
+steps:
+  - checkout
+  - semgrep-check-local:
+      options: << parameters.options >>
+      git-base-revision: <<#parameters.git-base-revision >><< parameters.git-base-revision >><</parameters.git-base-revision >><<^parameters.git-base-revision >><< parameters.git-default-base-revision >><</parameters.git-base-revision >>
+      run-security-checks: << parameters.run-security-checks >>
+      run-bestpractice-checks: << parameters.run-bestpractice-checks >>
+      disabled-signatures: << parameters.disabled-signatures >>
+      fail-on-findings: << parameters.fail-on-findings >>
+      min-fail-severity: << parameters.min-fail-severity >>
+      do-diff-scan: << parameters.do-diff-scan >>
+      update-rules: << parameters.update-rules >>

--- a/src/jobs/wiz-docker.yml
+++ b/src/jobs/wiz-docker.yml
@@ -1,0 +1,60 @@
+description: |
+  Test docker containers against SecOps-defined rules for misconfigurations.
+
+  Wiz is a security tool owned by the SecOps team to monitor for vulnerabilities, misconfigurations, errors, and incidents
+  occurring in Apollo's public cloud environments.
+
+  Wiz provides the ability to scan built Docker containers for vulnerabilities. Use this job to assess containers
+  as you're building them in your pipeline to ensure the container doesn't contain vulnerabilities that should
+  be fixed before the container is used in production. SecOps manages the policy used to determine if jobs should pass/fail
+  based on the vulnerabilities found. You can ensure jobs will never fail (regardless of SecOps policy) via the
+  fail-on-findings parameter.
+
+  Note that this job relies on your container being built already. You will need to tell CircleCI about
+  this dependency via the 'requires' keyword.
+
+  To pass the built container into this orb, you will need to save the built container as a tar and use CircleCI workspaces to
+  present the tar to this job. This job will scan a tar file containing a docker image saved to <workspace>/container/<name>.tar.
+  This directory should contain exactly one tar.
+
+  See this job's usage information for an example of building a container, saving it to a tar, exporting it to a workspace,
+  and running this job to scan it.
+
+  Results from this scan are printed to stdout as part of the execution of the job. Additionally, scan results
+  are uploaded as a build artifact to this job.
+
+parameters:
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings that violate Wiz policy
+    default: true
+  workspace-dir:
+    type: string
+    description: The path in the executor where the workspace should be mounted.
+    default: /tmp/workspace
+  wiz-policies:
+    type: string
+    description: One or more Wiz IAC policies to use during this scan. If specifying multiple, they should be comma-separated
+    default: Apollo-Default-Vulnerabilities-Policy
+
+executor:
+  name: wiz-ci
+
+working_directory: /tmp/project
+
+steps:
+  - setup_remote_docker
+  - attach_workspace:
+      at: << parameters.workspace-dir >>
+  - run:
+      name: Update Wiz
+      command: |
+        python3 /app/install-wiz.py
+  - run:
+      name: Authenticate with Wiz
+      command: |
+        /app/wizcli/wizcli auth --id ${WIZCLI_ID} --secret ${WIZCLI_SECRET}
+  - wiz-docker-check-local:
+      fail-on-findings: << parameters.fail-on-findings >>
+      workspace-dir: << parameters.workspace-dir >>
+      wiz-policies: << parameters.wiz-policies >>

--- a/src/jobs/wiz-iac.yml
+++ b/src/jobs/wiz-iac.yml
@@ -1,0 +1,48 @@
+description: |
+  Test infrastructure-as-code against SecOps-defined rules for misconfigurations.
+
+  Wiz is a security tool owned by the SecOps team to monitor for vulnerabilities, misconfigurations, errors, and incidents
+  occurring in Apollo's public cloud environments.
+
+  Wiz provides the ability to scan IAC files like terraform documents, dockerfiles, etc. to identify vulnerabilities
+  that will be introduced if the IAC file is executed. Use this job to prevent vulnerabilities from being introduced
+  via IAC. SecOps manages the policy used to determine if jobs should pass/fail based on the vulnerabilities found.
+  You can ensure jobs will never fail (regardless of SecOps policy) via the fail-on-findings parameter.
+
+  Results from this scan are printed to stdout as part of the execution of the job. Additionally, scan results
+  are uploaded as a build artifact to this job.
+
+parameters:
+  fail-on-findings:
+    type: boolean
+    description: Indicate if this check should fail if there are any findings >= min-fail-severity
+    default: true
+  do-diff-scan:
+    type: boolean
+    description: Set to False if you want to scan all files in the repo, not just changed files.
+    default: true
+  wiz-policies:
+    type: string
+    description: One or more Wiz IAC policies to use during this scan. If specifying multiple, they should be comma-separated
+    default: Apollo-Default-IAC-Policy
+
+executor:
+  name: wiz-ci
+
+working_directory: /tmp/project
+
+steps:
+  - checkout
+  - run:
+      name: Update Wiz
+      command: |
+        # This script provided by the executor
+        python3 /app/install-wiz.py
+  - run:
+      name: Authenticate with Wiz
+      command: |
+        /app/wizcli/wizcli auth --id ${WIZCLI_ID} --secret ${WIZCLI_SECRET}
+  - wiz-iac-check-local:
+      fail-on-findings: << parameters.fail-on-findings >>
+      do-diff-scan: << parameters.do-diff-scan >>
+      wiz-policies: << parameters.wiz-policies >>


### PR DESCRIPTION
This moves the various CCI jobs built to run security scans on Apollo repos over from our internal orb here. Making this change so that the security scans can be run on apollographql org repos as well. As we found out last week, there is not currently a mechanism to make a private CCI orb available to a second organization, which means that if these jobs remain in the internal orb, we cannot use them for the ApolloGraphQL github organization.