### PR TITLE
Housekeeping/debugging logs for why we are not cancelling all workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2023-02-24
+
+### Changed
+
+- The command `circleci-continue-long-job-cancel` now recognizes all workflows which have not been stopped. This will pick up ALL long running CircleCI Jobs, and not just ones which are `on-hold`
+
 ## [1.0.21] - 2023-02-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold (aka yet to be approved approval jobs) have a name containing specified words
+- The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warnings - for workflows where all the on hold (aka yet to be approved approval jobs) have a name containing specified words
 
 ## [1.0.19] - 2023-02-06
 
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- further reduce the size of code generated during slack-notify-compact command
+- further reduce the size of code generated during `slack-notify-compact` command
 - setup command only downloads repository once
 
 ## [1.0.17] - 2023-01-27
@@ -71,18 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- circleci-stop-if command
+- `circleci-stop-if` command
 
 ### Changed
 
 - modifications to this orb now require updated CHANGELOG. Versions before this point will be documented in a best effort approach, going forward changelog entries are enforced.
-- slack-circleci-build has an optional who-did-it parameter which allows overriding author information
+- `slack-circleci-build` has an optional who-did-it parameter which allows overriding author information
 
 ## [1.0.11] - 2023-01-03
 
 ### Changed
 
-- slack-circleci-build has an optional link parameter in case the default Circle URL does not work for your use case
+- `slack-circleci-build` has an optional link parameter in case the default Circle URL does not work for your use case
 
 ## [1.0.10] - 2022-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,58 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.21] - 2023-02-22
+
 ### Changed
+
 - Added optional argument to GitHub commands to let them be configured to run even if prior steps failed
 
 ## [1.0.20] - 2023-02-06
+
 ### Added
 
-  - The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold (aka yet to be approved approval jobs) have a name containing specified words
+- The command `circleci-continue-long-job-cancel` can ignore - that is not emit age warings - for workflows where all the on hold (aka yet to be approved approval jobs) have a name containing specified words
 
 ## [1.0.19] - 2023-02-06
+
 ### Fixed
+
 - 1.0.13 introduced a bug with `circleci-continue-long-job-cancel`'s ability to correctly fetch user
   info for better Slack messages.
 
 ## [1.0.18] - 2023-02-03
+
 ### Fixed
-  - further reduce the size of code generated during slack-notify-compact command
-  - setup command only downloads repository once
+
+- further reduce the size of code generated during slack-notify-compact command
+- setup command only downloads repository once
 
 ## [1.0.17] - 2023-01-27
 
 ### Fixed
+
 - 1.0.13 introduced a bug with `circleci-continue-long-job-cancel`'s datetime comparisons.
 
 ## [1.0.16] - 2023-01-27
 
 ### Fixed
+
 - 1.0.14 introduced a bug with some Python `requests` helpers.
 
 ## [1.0.15] - 2023-01-27
 
 ### Fixed
+
 - 1.0.14 introduced a bug in the way that our Python scripts function in regards to argument parsing.
 
 ## [1.0.14] - 2023-01-27
 
 ### Added
+
 - Alerting included now for errors originating from CircleCI
 - Command: `circleci-continue-long-job-cancel`
   - `--n-windows` argument:
@@ -50,44 +62,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.13] - 2023-01-23
 
 ### Fixed
+
 - The Command `circleci-continue-long-job-cancel` did not have the ability to properly paginate
   over results. This release makes it such that the Cancel command will now walk over a period of
   time, instead of a set number of pages.
 
 ## [1.0.12] - 2023-01-20
+
 ### Added
-  - circleci-stop-if command
+
+- circleci-stop-if command
 
 ### Changed
-  - modifications to this orb now require updated CHANGELOG. Versions before this point will be documented in a best effort approach, going forward changelog entries are enforced.
-  - slack-circleci-build has an optional who-did-it parameter which allows overriding author information
 
+- modifications to this orb now require updated CHANGELOG. Versions before this point will be documented in a best effort approach, going forward changelog entries are enforced.
+- slack-circleci-build has an optional who-did-it parameter which allows overriding author information
 
 ## [1.0.11] - 2023-01-03
 
 ### Changed
-  - slack-circleci-build has an optional link parameter in case the default Circle URL does not work for your use case
 
+- slack-circleci-build has an optional link parameter in case the default Circle URL does not work for your use case
 
 ## [1.0.10] - 2022-12-07
 
 ### Changed
-  - the long job canceller script has the following changes:
-    - better handles failures on branches that have not been pushed to
-    - handle situation where robot makes a commit and human merges it (page the human)
-    - don't warn robots to take action
+
+- the long job canceller script has the following changes:
+  - better handles failures on branches that have not been pushed to
+  - handle situation where robot makes a commit and human merges it (page the human)
+  - don't warn robots to take action
 
 ## [1.0.8] - 2022-11-30
 
 ### Changed
-  - build fix
 
+- build fix
 
 ## [1.0.7] - 2023-11-30
+
 ### Added
-  - enrich-mustache-folder command
-  - git-diff-set-parameters command
-  - enrich-mustache-from-path-filter job
+
+- enrich-mustache-folder command
+- git-diff-set-parameters command
+- enrich-mustache-from-path-filter job
 
 ### Changed
-  - better documentation for enrich-mustache command
+
+- better documentation for enrich-mustache command

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -66,7 +66,8 @@ def find_old_workflow_ids(
         window_end_cancel,
         window_end_warn,
         headers):
-    print(f'Window to paginate through: [start:{window_start}, cancel:{window_end_cancel}, warn:{window_end_warn}]')
+    print(
+        f'Window to paginate through: [start:{window_start}, cancel:{window_end_cancel}, warn:{window_end_warn}]')
     for current_pipeline in get_all_items(f"/project/gh/{repo_slug}/pipeline", headers, None):
         # Paginate through only those pipelines which started inside our given window
         created_at = pipeline_created_at_to_datetime(current_pipeline)
@@ -105,7 +106,7 @@ def find_old_workflow_ids(
 
 def matches_any_in_list(str, list):
     for current in list:
-        if ( str.find(current) > -1 ):
+        if (str.find(current) > -1):
             return True
     return False
 
@@ -113,9 +114,9 @@ def matches_any_in_list(str, list):
 def has_only_ignored_jobs(current_info, ignore, headers):
     for current in get_workflow_pending_approval_jobs(current_info['id'], headers):
         if not matches_any_in_list(current['name'], ignore):
-          # if we are here then we have a job name that is not filtered by our ignore list
-          # (so we do not _only_ have ignored jobs). Short circuit, the answer to our question is False
-          return False
+            # if we are here then we have a job name that is not filtered by our ignore list
+            # (so we do not _only_ have ignored jobs). Short circuit, the answer to our question is False
+            return False
     return True
 
 

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -97,7 +97,7 @@ def find_old_workflow_ids(
 
             if job_status:
                 yield {
-                    "job_status": "age_warning",
+                    "job_status": job_status,
                     "name": current_workflow['name'],
                     "id": current_workflow['id'],
                     "username": username

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -80,9 +80,9 @@ def find_old_workflow_ids(
         for current_workflow in get_all_items(f"/pipeline/{current_pipeline['id']}/workflow", headers, None):
             job_status = None
             username = get_workflow_started_by(current_workflow, headers)
-            logging_detail = f'[{created_at}] ({current_workflow["name"]}), started by gh:{username}. See more info at: https://app.circleci.com/pipelines/workflows/{current_workflow["id"]}'
+            logging_detail = f'[{created_at}] ({current_workflow["name"]})[{current_workflow["status"]}], started by gh:{username}. See more info at: https://app.circleci.com/pipelines/workflows/{current_workflow["id"]}'
 
-            if current_workflow["status"] == "on_hold":
+            if not current_workflow.get('stopped_at'):
                 if (created_at < window_end_cancel):
                     print(f'found too old workflow {logging_detail}')
                     job_status = "too_old"
@@ -90,7 +90,7 @@ def find_old_workflow_ids(
                 elif username in robot_committers:
                     continue
 
-                else:
+                elif current_workflow['status'] == 'on_hold':
                     print(f'midlife warning for workflow {logging_detail}')
                     job_status = "age_warning"
 

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -77,7 +77,12 @@ def find_old_workflow_ids(repo_slug, window_start, window_end, headers):
                 created_at_str = current_workflow["created_at"]
                 created_at = isoparse(created_at_str)
 
-                if ((created_at < (now - job_midlife_warning)) and (created_at > (now - job_life_clock))):
+                if (created_at < (now - job_life_clock)):
+                    username = get_workflow_started_by(
+                        current_workflow, headers)
+                    yield {"job_status": "too_old", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
+
+                if (created_at < (now - job_midlife_warning)):
                     username = get_workflow_started_by(
                         current_workflow, headers)
                     if username in robot_committers:
@@ -85,10 +90,6 @@ def find_old_workflow_ids(repo_slug, window_start, window_end, headers):
 
                     yield {"job_status": "age_warning", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
 
-                if (created_at < (now - job_life_clock)):
-                    username = get_workflow_started_by(
-                        current_workflow, headers)
-                    yield {"job_status": "too_old", "name": current_workflow['name'], "id": current_workflow['id'], "username": username}
 
 
 def matches_any_in_list(str, list):

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -90,9 +90,10 @@ def find_old_workflow_ids(
                     print(f'found too old workflow {logging_detail}')
                     job_status = "too_old"
 
+                elif username in robot_committers:
+                    continue
+
                 else:
-                    if username in robot_committers:
-                        continue
                     print(f'midlife warning for workflow {logging_detail}')
                     job_status = "age_warning"
 

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -83,9 +83,6 @@ def find_old_workflow_ids(
             logging_detail = f'[{created_at}] ({current_workflow["name"]}), started by gh:{username}. See more info at: https://app.circleci.com/pipelines/workflows/{current_workflow["id"]}'
 
             if current_workflow["status"] == "on_hold":
-                created_at_str = current_workflow["created_at"]
-                created_at = isoparse(created_at_str)
-
                 if (created_at < window_end_cancel):
                     print(f'found too old workflow {logging_detail}')
                     job_status = "too_old"


### PR DESCRIPTION
# Motivation

Many CCI jobs are passing through our filters because they're actually still stuck running (errantly). These are problems with CCI, not us.