### PR TITLE
Only fail error tflint with error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2023-03-20
+
+- Only fail tflint checks when error occurs instead of warnings
+
 ## [1.0.22] - 2023-02-24
 
 ### Changed

--- a/src/scripts/tflint_all.sh
+++ b/src/scripts/tflint_all.sh
@@ -20,7 +20,7 @@ function check_directories_in {
             echo "========================================"
             echo "tflint-ing $(pwd)"
             echo "========================================"
-            tflint -c $CONFIG_FILE_LOCATION
+            tflint -c $CONFIG_FILE_LOCATION --minimum-failure-severity=error
             popd > /dev/null
         fi
     done


### PR DESCRIPTION
Only error out on errors instead of warning to avoid introducing temporary side effects.

A issue as been created to address this change: https://github.com/orgs/mdg-private/projects/23?pane=issue&itemId=23436062