### PR TITLE
✨  add option to update last comment instead of delete

### DIFF
--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -41,7 +41,7 @@ steps:
           -q '.[] | select(.user.login == "<< parameters.bot-making-comments >>") | select(.body | startswith("## << parameters.title >>")) | .id'`
         COMMENT_IDS_ARRAY=( $COMMENT_IDS )
         LAST=""
-        if [ ${#COMMENT_IDS_ARRAY[@]} -ne 0 ]; then
+        if [ ${#COMMENT_IDS_ARRAY[@]} -ne 0 ] && [ "<< parameters.update-last >>" == "true" ]; then
             LAST=${COMMENT_IDS_ARRAY[${#COMMENT_IDS_ARRAY[@]}-1]}
         fi
 

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -7,6 +7,13 @@ parameters:
   command:
     type: string
     description: A command which must produce a /tmp/notification.txt file. If no, or empty file, produced step is halted
+  update-last:
+    type: boolean
+    description: Update the last comment from this bot with this title instead of creating a new one
+    default: false
+  bot-making-comments:
+    type: string
+    description: name of the bot making all these comments
   do-when:
     type: string
     description: Value passed to "when" parameter on job. Useful to let job run even after a prior step failed
@@ -29,5 +36,26 @@ steps:
 
         echo "## << parameters.title >>" > /tmp/preamble.txt
         cat /tmp/preamble.txt /tmp/notification.txt > /tmp/constructed_forslack.txt
-        gh pr comment "$CIRCLE_PULL_REQUEST" -F /tmp/constructed_forslack.txt
+
+        COMMENT_IDS=`gh api repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_NUMBER/comments \
+          -q '.[] | select(.user.login == "<< parameters.bot-making-comments >>") | select(.body | startswith("## << parameters.title >>")) | .id'`
+        COMMENT_IDS_ARRAY=( $COMMENT_IDS )
+        LAST=""
+        if [ ${#COMMENT_IDS_ARRAY[@]} -ne 0 ]; then
+            LAST=${COMMENT_IDS_ARRAY[${#COMMENT_IDS_ARRAY[@]}-1]}
+        fi
+
+        if [ "$LAST" == "" ]; then
+            echo No existing comment, create a new one
+            gh pr comment "$CIRCLE_PULL_REQUEST" -F /tmp/constructed_forslack.txt
+        else
+            echo comment exists, update: $LAST
+            body=`cat /tmp/constructed_forslack.txt`
+            gh api --method PATCH \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/comments/$LAST \
+                -f body="$body"
+        fi
+
       when: << parameters.do-when >>

--- a/src/commands/github-bot-delete-bot-comments.yml
+++ b/src/commands/github-bot-delete-bot-comments.yml
@@ -10,6 +10,10 @@ parameters:
   really-delete-comments:
     type: boolean
     default: true
+  skip-last:
+    type: boolean
+    description: Update the last comment from this bot with this title instead of creating a new one
+    default: false
   do-when:
     type: string
     description: Value passed to "when" parameter on job. Useful to let job run even after a prior step failed
@@ -34,7 +38,15 @@ steps:
             exit 0
           fi
 
-          gh api repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_NUMBER/comments \
-            -q '.[] | select(.user.login == "<< parameters.bot-making-comments >>") | select(.body | startswith("## << parameters.title >>")) | .id' \
-          | xargs -I{} -n1 gh api repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/comments/{} -X=DELETE
+          COMMENT_IDS=`gh api repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_NUMBER/comments \
+            -q '.[] | select(.user.login == "<< parameters.bot-making-comments >>") | select(.body | startswith("## << parameters.title >>")) | .id'`
+          COMMENT_IDS_ARRAY=( $COMMENT_IDS )
+          if [ ${#COMMENT_IDS_ARRAY[@]} -ne 0 ]; then
+              unset COMMENT_IDS_ARRAY[${#COMMENT_IDS_ARRAY[@]}-1]
+          fi
+          for id in "${COMMENT_IDS_ARRAY[@]}"
+          do
+              echo Delete comment: $id
+              gh api repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/comments/$id -X=DELETE
+          done
       when: << parameters.do-when >>

--- a/src/commands/github-bot-delete-bot-comments.yml
+++ b/src/commands/github-bot-delete-bot-comments.yml
@@ -41,7 +41,7 @@ steps:
           COMMENT_IDS=`gh api repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_NUMBER/comments \
             -q '.[] | select(.user.login == "<< parameters.bot-making-comments >>") | select(.body | startswith("## << parameters.title >>")) | .id'`
           COMMENT_IDS_ARRAY=( $COMMENT_IDS )
-          if [ ${#COMMENT_IDS_ARRAY[@]} -ne 0 ]; then
+          if [ ${#COMMENT_IDS_ARRAY[@]} -ne 0 ] && [ "<< parameters.skip-last >>" == "true" ]; then
               unset COMMENT_IDS_ARRAY[${#COMMENT_IDS_ARRAY[@]}-1]
           fi
           for id in "${COMMENT_IDS_ARRAY[@]}"

--- a/src/jobs/alert-github.yml
+++ b/src/jobs/alert-github.yml
@@ -36,6 +36,10 @@ parameters:
     type: boolean
     default: true
     description: "Delete comments previously made by the delete-bot-comments bot"
+  update-last:
+    type: boolean
+    description: Update the last comment from this bot with this title instead of creating a new one
+    default: false
 docker:
   - image: cimg/base:stable
 resource_class: small
@@ -55,6 +59,7 @@ steps:
       title: << parameters.title >>
       bot-making-comments: << parameters.bot-making-comments >>
       really-delete-comments: << parameters.delete-bot-comments >>
+      skip-last: << parameters.update-last >>
   - proceed-if-changes:
       path: << parameters.path >>
       name-filter: << parameters.name-filter >>
@@ -63,5 +68,7 @@ steps:
   - github-bot-comment-on-pr:
       title: << parameters.title >>
       command: << parameters.notification-command >>
+      bot-making-comments: << parameters.bot-making-comments >>
+      update-last: << parameters.update-last >>
   - store_artifacts:
      path: /tmp/notification.txt


### PR DESCRIPTION
We have a bunch of auto comments on PRs and right now every time you push it creates a notification for each one. This can be very noisy. This PR adds a "update-last" option to the alert github command, that will instead of deleting the previous comment update the contents. This makes it so the PR still has the latest info, but doesn't create unnecessary  noise. It defaults to false, so it's still opt in 