### PR TITLE
"main is broken please deploy" checker needs better targetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2023-05-18
+
+- circleci-job-cancelled "`main_is_borked`" script only alerts on awaiting approval jobs "to prod?" vs previous logic (which was targetting anything not our first (internal) deploy environment. This should be more generic and avoid some issues internally we were seeing with alerting people about irrelevant things.
+
 ## [1.2.3] - 2023-05-18
 
 - setup command no longer saves the downloaded files as artifacts in Circle.

--- a/src/scripts/circleci-job-canceller/main_is_borked.py
+++ b/src/scripts/circleci-job-canceller/main_is_borked.py
@@ -114,8 +114,11 @@ def main(githubtoken, orgreposlug, circleapitoken):
         # regardless main's HEAD commit spends most of its time here, experimentally
         pending_workflows = []
         [pending_workflows.append(x) for x in commit_info.get("status").get("contexts") if (
-            ((x.get("state") == "PENDING") and ("ci/circleci" in x.get("context"))) and not("dev0" in x.get("context")))]
-        # pending workflows targetting dev0 don't deserve a callout by themselves
+            ((x.get("state") == "PENDING") and ("ci/circleci" in x.get("context"))) and ("to prod?" in x.get("context")))]
+        # only pending workflows to PROD deserve a callback
+        # note that this is specially worded: "to prod?" to catch only approval jobs asking if we want to deploy to prod
+        # pending workflows without "to prod?" may be something else: pending deploys to other environments or pending
+        # workflows asking about "rollback SERVICENAME prod?"
 
         if (len(pending_workflows) > 0):
             jobs_started_str = pending_workflows[0].get("createdAt")


### PR DESCRIPTION
We ONLY care about pending jobs going to our prod environment. 

Previously we cared about everything NOT targeting our first stage environment. This logic change should reduce the amount of incorrect pings