### PR TITLE
github-bot-comment-on-pr: work with long comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.5] - 2023-05-31
+
+- `github-bot-comment-on-pr` can now update comments with longer text without running into command line length limits.
+
 ## [1.2.4] - 2023-05-18
 
 - circleci-job-cancelled "`main_is_borked`" script only alerts on awaiting approval jobs "to prod?" vs previous logic (which was targetting anything not our first (internal) deploy environment. This should be more generic and avoid some issues internally we were seeing with alerting people about irrelevant things.

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -59,12 +59,11 @@ steps:
             gh pr comment "$CIRCLE_PULL_REQUEST" -F /tmp/constructed_forslack.txt
         else
             echo comment exists, update: $LAST
-            body=`cat /tmp/constructed_forslack.txt`
             gh api --method PATCH \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 /repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/comments/$LAST \
-                -f body="$body"
+                -F body=@/tmp/constructed_forslack.txt
         fi
 
       when: << parameters.do-when >>


### PR DESCRIPTION
If the comment we are updating is very long, the current code will be too long for the shell to `exec`. Fortunately `gh api` has a built-in way of sending a field from a file.

See https://app.circleci.com/pipelines/github/mdg-private/monorepo/53674/workflows/1409eaa5-31e9-4adc-8d3d-f52cec3b6f08/jobs/1025530 for an example of a problem.