### PR TITLE
handle too long comments part two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6] - 2023-06-23
+
+- `github-bot-comment-on-pr` now handles comments that are too long for inline Github PR comments, by posting to a secret Github Gist and linking from the comment.
+
 ## [1.2.5] - 2023-05-31
 
 - `github-bot-comment-on-pr` can now update comments with longer text without running into command line length limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.6] - 2023-06-23
 
-- `github-bot-comment-on-pr` now handles comments that are too long for inline Github PR comments, by posting to a secret Github Gist and linking from the comment.
+- `github-bot-comment-on-pr` (command) and `alert-github` (job) better handle comments that are too long for inline Github PR comments. You may post to a secret gist (use the "report.md" option), or print inline (using the "print" option, the default), by using the `overlarge-content-to` parameter.
 
 ## [1.2.5] - 2023-05-31
 

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -37,8 +37,8 @@ steps:
         echo "## << parameters.title >>" > /tmp/preamble.txt
         cat /tmp/preamble.txt /tmp/notification.txt > /tmp/constructed_forslack.txt
 
-        if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65000 ]; then
-           # too big for Github Pull Requests Comments
+        if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65 ]; then
+           # get file size in K. 65K is too big for Github Pull Requests Comments (API errors)
            cp /tmp/constructed_forslack.txt /tmp/report.md
            echo "Github comment limit exceeded" > /tmp/constructed_forslack.txt
         fi

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -42,7 +42,7 @@ steps:
            cp /tmp/constructed_forslack.txt /tmp/report.md
 
            echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
-           echo -n "Github comment limit exceeded: " >> /tmp/constructed_forslack.txt
+           echo "Output redirected to the full report, linked below, as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
         fi
 
         if [ -f /tmp/report.md ]; then

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -37,6 +37,12 @@ steps:
         echo "## << parameters.title >>" > /tmp/preamble.txt
         cat /tmp/preamble.txt /tmp/notification.txt > /tmp/constructed_forslack.txt
 
+        if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65000 ]; then
+           # too big for Github Pull Requests Comments
+           cp /tmp/constructed_forslack.txt /tmp/report.md
+           echo "Github comment limit exceeded" > /tmp/constructed_forslack.txt
+        fi
+
         if [ -f /tmp/report.md ]; then
           GIST_URL=$(gh gist create /tmp/report.md)
           echo >>/tmp/constructed_forslack.txt

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -18,6 +18,10 @@ parameters:
     type: string
     description: Value passed to "when" parameter on job. Useful to let job run even after a prior step failed
     default: on_success
+  send-over-limit-output:
+    type: enum
+    enum: ["gist", "print"]
+    default: "print"
 steps:
   - run:
       name: Comment in PR
@@ -39,10 +43,19 @@ steps:
 
         if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65 ]; then
            # get file size in K. 65K is too big for Github Pull Requests Comments (API errors)
-           cp /tmp/constructed_forslack.txt /tmp/report.md
+           if [ "<< parameters.send-over-limit-output >>" = "gist" ]; then
+               cp /tmp/constructed_forslack.txt /tmp/report.md
 
-           echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
-           echo "Output redirected to the full report, linked below, as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
+               echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
+               echo "Output redirected to the full report, linked below, as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
+            fi
+
+            if [ "<< parameters.send-over-limit-ouput >>" = "print" ]; then
+               cat /tmp/constructed_for_slack.txt
+
+               echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
+               echo "Output redirected to be in the build step output of the 'Comment in PR' build [in your Circle build]($CIRCLE_BUILD_URL)" >> /tmp/constructed_forslack.txt
+            fi
         fi
 
         if [ -f /tmp/report.md ]; then

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -50,7 +50,7 @@ steps:
                echo "Output redirected to the full report, linked below, as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
             fi
 
-            if [ "<< parameters.send-over-limit-ouput >>" = "print" ]; then
+            if [ "<< parameters.send-over-limit-output >>" = "print" ]; then
                cat /tmp/constructed_for_slack.txt
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -18,7 +18,7 @@ parameters:
     type: string
     description: Value passed to "when" parameter on job. Useful to let job run even after a prior step failed
     default: on_success
-  send-over-limit-output:
+  overlarge-content-to:
     description: If the total size of /tmp/notification.txt is larger than Github Pull Request comment limits, instead output the content to this location.
     type: enum
     enum: ["report.md", "print"]
@@ -44,14 +44,14 @@ steps:
 
         if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65 ]; then
            # get file size in K. 65K is too big for Github Pull Requests Comments (API errors)
-           if [ "<< parameters.send-over-limit-output >>" = "report.md" ]; then
+           if [ "<< parameters.overlarge-content-to >>" = "report.md" ]; then
                cp /tmp/constructed_forslack.txt /tmp/report.md
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
                echo "Output redirected to the full report, linked below, as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
             fi
 
-            if [ "<< parameters.send-over-limit-output >>" = "print" ]; then
+            if [ "<< parameters.overlarge-content-to >>" = "print" ]; then
                cat /tmp/constructed_forslack.txt
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -19,8 +19,9 @@ parameters:
     description: Value passed to "when" parameter on job. Useful to let job run even after a prior step failed
     default: on_success
   send-over-limit-output:
+    description: If the total size of /tmp/notification.txt is larger than Github Pull Request comment limits, instead output the content to this location.
     type: enum
-    enum: ["gist", "print"]
+    enum: ["report.md", "print"]
     default: "print"
 steps:
   - run:
@@ -43,7 +44,7 @@ steps:
 
         if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65 ]; then
            # get file size in K. 65K is too big for Github Pull Requests Comments (API errors)
-           if [ "<< parameters.send-over-limit-output >>" = "gist" ]; then
+           if [ "<< parameters.send-over-limit-output >>" = "report.md" ]; then
                cp /tmp/constructed_forslack.txt /tmp/report.md
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
@@ -54,7 +55,7 @@ steps:
                cat /tmp/constructed_forslack.txt
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
-               echo "Output redirected to be in the build step output of the 'Comment in PR' build [in your Circle build]($CIRCLE_BUILD_URL)" >> /tmp/constructed_forslack.txt
+               echo "Output redirected to be in the build step output of the 'Comment in PR' build [in your Circle build]($CIRCLE_BUILD_URL), as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
             fi
         fi
 

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -55,7 +55,7 @@ steps:
                cat /tmp/constructed_forslack.txt
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
-               echo "Output redirected to be in the build step output of the 'Comment in PR' build [in your Circle build]($CIRCLE_BUILD_URL), as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
+               echo "Output redirected to be in the build step output of 'Comment in PR' [in your CircleCI build]($CIRCLE_BUILD_URL), as otherwise comment would be too long." >> /tmp/constructed_forslack.txt
             fi
         fi
 

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -40,7 +40,9 @@ steps:
         if [ $(du -k /tmp/constructed_forslack.txt | cut -f1) -gt 65 ]; then
            # get file size in K. 65K is too big for Github Pull Requests Comments (API errors)
            cp /tmp/constructed_forslack.txt /tmp/report.md
-           echo "Github comment limit exceeded" > /tmp/constructed_forslack.txt
+
+           echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
+           echo -n "Github comment limit exceeded: " >> /tmp/constructed_forslack.txt
         fi
 
         if [ -f /tmp/report.md ]; then

--- a/src/commands/github-bot-comment-on-pr.yml
+++ b/src/commands/github-bot-comment-on-pr.yml
@@ -51,7 +51,7 @@ steps:
             fi
 
             if [ "<< parameters.send-over-limit-output >>" = "print" ]; then
-               cat /tmp/constructed_for_slack.txt
+               cat /tmp/constructed_forslack.txt
 
                echo "## << parameters.title >>" > /tmp/constructed_forslack.txt
                echo "Output redirected to be in the build step output of the 'Comment in PR' build [in your Circle build]($CIRCLE_BUILD_URL)" >> /tmp/constructed_forslack.txt

--- a/src/jobs/alert-github.yml
+++ b/src/jobs/alert-github.yml
@@ -74,6 +74,6 @@ steps:
       command: << parameters.notification-command >>
       bot-making-comments: << parameters.bot-making-comments >>
       update-last: << parameters.update-last >>
-      send-over-limit-output: << parameters.overlarge-content-to >>
+      overlarge-content-to: << parameters.overlarge-content-to >>
   - store_artifacts:
      path: /tmp/notification.txt

--- a/src/jobs/alert-github.yml
+++ b/src/jobs/alert-github.yml
@@ -8,7 +8,7 @@ parameters:
     description: 'Title to be given to this PR comment in Github.'
   notification-command:
     type: string
-    description: 'Bash command which will be run to generate the markdown payload to comment on the PR in Github. Command must send desired output to /tmp/notification.txt '
+    description: 'Bash command which will be run to generate the markdown payload to comment on the PR in Github. Command must send desired output to /tmp/notification.txt OR may send output to /tmp/report.md, which will be used to create a secret gist.'
   path:
     type: string
     description: '`path` parameter to be passed to `proceed-if-changes`'
@@ -40,6 +40,10 @@ parameters:
     type: boolean
     description: Update the last comment from this bot with this title instead of creating a new one
     default: false
+  overlarge-content-to:
+    type: enum
+    enum: ["report.md", "print"]
+    default: "print"
 docker:
   - image: cimg/base:stable
 resource_class: small
@@ -70,5 +74,6 @@ steps:
       command: << parameters.notification-command >>
       bot-making-comments: << parameters.bot-making-comments >>
       update-last: << parameters.update-last >>
+      send-over-limit-output: << parameters.overlarge-content-to >>
   - store_artifacts:
      path: /tmp/notification.txt


### PR DESCRIPTION
While the changes in https://github.com/apollographql/internal-platform-orb/pull/36 helped exceed shell limits, we ran across a (seemingly undocumented!) pull request comment size limit.

Check to see if our comment would exceed that limit, and if so redirect output to the secret gist creating report introduced in https://github.com/apollographql/internal-platform-orb/pull/33

Output can be redirected to a secret gist, or simply displayed as part of the Circle build output

Example output (to a gist: "report.md" option. "[redacted] changes is the title we passed into our usage of the command/job)

![image](https://github.com/apollographql/internal-platform-orb/assets/20831/7365332a-acea-4684-81c1-56cdea46045f)

Example output (printed as part of the CircleCI build output: "print" option)

![image](https://github.com/apollographql/internal-platform-orb/assets/20831/665da4a8-41ec-4cd5-8641-80db51cae20a)
