### PR TITLE
new features 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.7] - 2023-07-07
+
+- `enrich-mustache-from-path-file` now includes a `pre-process-command` which is executed right before rendering the specified config file's mustache template. On a side note, have you heard about `jq`'s `+` operator?
+- `gcp-authorize` now works on MacOS based executors
+- `circleci-stop-if-not`, to compliment `circleci-stop-if`
+
 ## [1.2.6] - 2023-06-23
 
 - `github-bot-comment-on-pr` (command) and `alert-github` (job) better handle comments that are too long for inline Github PR comments. You may post to a secret gist (use the "report.md" option), or print inline (using the "print" option, the default), by using the `overlarge-content-to` parameter.

--- a/src/commands/circleci-stop-if-not.yml
+++ b/src/commands/circleci-stop-if-not.yml
@@ -1,0 +1,22 @@
+description: >-
+  Helper command which, like circleci-stop-if will `halt` the entire execution of the running `job`, but does so if the value of
+  `value` parameter is NOT the value of the `continue-if-value-is` parameter.
+
+  Circle's "when" conditions are great, but you could use this as a pre-step in a workflow to avoid executing a job
+
+parameters:
+  value:
+    type: string
+    description: A value - maybe even a Circle parameter - to check
+  continue-if-value-is:
+    type: string
+    description: If the value parameter matches this value, halt job execution. Job will still be green, but further steps will not happen
+
+steps:
+  - run:
+      name: Halt if actual != expected
+      command: |
+        if [ ! "<< parameters.value >>" = "<< parameters.continue-if-value-is >>" ];
+        then
+          circleci-agent step halt
+        fi

--- a/src/commands/gcp-authorize.yml
+++ b/src/commands/gcp-authorize.yml
@@ -39,7 +39,11 @@ steps:
           # not base64 encoded? Great!
           echo "does not need base64 decoding"
         else
-          base64 -d --ignore-garbage -i /tmp/google_auth.json > /tmp/google_auth_decoded.json
+          if [ "$(uname)" = "Darwin" ]; then
+              base64 -d -i /tmp/google_auth.json -o /tmp/google_auth_decoded.json
+          else
+              base64 -d --ignore-garbage -i /tmp/google_auth.json > /tmp/google_auth_decoded.json
+          fi
           mv /tmp/google_auth_decoded.json /tmp/google_auth.json
         fi
   - run:

--- a/src/jobs/enrich-mustache-from-path-filter.yml
+++ b/src/jobs/enrich-mustache-from-path-filter.yml
@@ -29,6 +29,9 @@ parameters:
   config-path:
     description: Location of the (mustache enriched) config file
     type: string
+  pre-process-command:
+    description: allows you to insert a command after set-parameters has generated a JSON file. Useful for post-processing same (ie with jq's + command)
+    default: ""
   mapping:
     description: >-
       Like path-filtering, the format is:
@@ -56,6 +59,7 @@ parameters:
         path-filtering behavior: given two matches the last one wins.
         Which is the last one? Potentially undefined behavior.
 
+        The resulting output will be written to /tmp/enrich-parameters.json
 
     type: string
 steps:
@@ -65,6 +69,13 @@ steps:
       base-revision: << parameters.base-revision >>
       output-path: << parameters.config-path >>
       mapping: << parameters.mapping >>
+  - run:
+      name: pre process command
+      command: << parameters.pre-process-command >>
+  - run:
+      name: debugging output (enrich-parameters)
+      command: cat /tmp/enrich-parameters.json
+
   - enrich-mustache:
       json-data-file-path: /tmp/enrich-parameters.json
       template-file-path: << parameters.config-path >>
@@ -72,8 +83,5 @@ steps:
   - run:
       name: debugging output (pipeline)
       command: cat /tmp/generated_pipeline.yml
-  - run:
-      name: debugging output (enrich-parameters)
-      command: cat /tmp/enrich-parameters.json
   - continuation/continue:
       configuration_path: /tmp/generated_pipeline.yml

--- a/src/jobs/enrich-mustache-from-path-filter.yml
+++ b/src/jobs/enrich-mustache-from-path-filter.yml
@@ -72,7 +72,8 @@ steps:
       mapping: << parameters.mapping >>
   - run:
       name: pre process command
-      command: << parameters.pre-process-command >>
+      command: |
+        << parameters.pre-process-command >>
   - run:
       name: debugging output (enrich-parameters)
       command: cat /tmp/enrich-parameters.json

--- a/src/jobs/enrich-mustache-from-path-filter.yml
+++ b/src/jobs/enrich-mustache-from-path-filter.yml
@@ -32,6 +32,7 @@ parameters:
   pre-process-command:
     description: allows you to insert a command after set-parameters has generated a JSON file. Useful for post-processing same (ie with jq's + command)
     default: ""
+    type: string
   mapping:
     description: >-
       Like path-filtering, the format is:


### PR DESCRIPTION
Bunch of new features:
  * `gcp-authorize`: now works on MacOS
  * `circleci-stop-if-not`: we have a `circleci-stop-if-not-pr` but not a generic command
  * `enrich-mustache-from-path-file` gives you a pre-process command to add MORE keys to your JSON file

(ie so that you could yes have one value that varies based on Git branch, but you could add more especially if they are constant)