### PR TITLE
gcp-oidc-authorize command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Dev
+
+- Added `gcp-oidc-authorize` as a new option for authenticating to GCP. This uses Open Identity Connect (OIDC) and the Identity Provider (IdP) that Circle makes available to jobs to authenticate to GCP via GCP's Workload Identity Federation. See [Circle's Docs](https://circleci.com/docs/openid-connect-tokens/#google-cloud-platform) for more info
+
 ## [1.2.7] - 2023-07-07
 
 - `enrich-mustache-from-path-file` now includes a `pre-process-command` which is executed right before rendering the specified config file's mustache template. On a side note, have you heard about `jq`'s `+` operator?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2023-07-28
+## [1.3.1] - 2023-08-04
 
 - Added `gcp-oidc-authorize` as a new option for authenticating to GCP. This uses Open Identity Connect (OIDC) and the Identity Provider (IdP) that Circle makes available to jobs to authenticate to GCP via GCP's Workload Identity Federation. See [Circle's Docs](https://circleci.com/docs/openid-connect-tokens/#google-cloud-platform) for more info
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Dev
+## [1.3.0] - 2023-07-28
 
 - Added `gcp-oidc-authorize` as a new option for authenticating to GCP. This uses Open Identity Connect (OIDC) and the Identity Provider (IdP) that Circle makes available to jobs to authenticate to GCP via GCP's Workload Identity Federation. See [Circle's Docs](https://circleci.com/docs/openid-connect-tokens/#google-cloud-platform) for more info
 

--- a/src/commands/gcp-oidc-authorize.yml
+++ b/src/commands/gcp-oidc-authorize.yml
@@ -1,0 +1,86 @@
+description: Authorize the GCP CLI using OIDC rather than receiving a service account's credentials via environment variable. This command creates an ephemeral GCP session by leveraging GCP Workload Identity. Workload Identity must be configured in the project you are attempting to authenticate to prior to using this command. Additionally, you will need to have installed the gcloud command line utility in your CI execution environment prior to using this command. This is a enhanced version of the gcp-cli orb's authorize command.
+parameters:
+  do-docker-login:
+    type: enum
+    default: ""
+    enum: ["", "true"]
+    description: "Have Docker use the retrieved creds to log into Google Artifact Registry, where we have a Docker registry. Likely will need to run setup_remote_docker command first. "
+  do-helm-login:
+    type: enum
+    default: ""
+    enum: ["", "true"]
+    description: "Have Helm use the retrieved creds to log into Google Artifact Registry, using Helm's support for OCI registries."
+  do-activate-application-default-creds:
+    type: enum
+    default: "true"
+    enum: ["","true"]
+    description: "Configure the environment to use the retrieved credentials as the Application Default Creds (ADC). This option does not work if delete-cred-file is true"
+  delete-cred-file:
+    type: enum
+    default: "false"
+    enum: ["false", "true"]
+    description: delete the credentials file
+  project-id:
+    type: env_var_name
+    default: GCP_PROJECT_ID
+    description: The name of the environment variable containing the GCP project ID to be authenticated to. For example, the named variable could contain "myproject-123456"
+  workload-identity-pool-id:
+    type: env_var_name
+    default: GCP_WIP_ID
+    description: The name of the environment variable containing the workload identity pool to use to authenticate to GCP
+  workload-identity-pool-provider-id:
+    type: env_var_name
+    default: GCP_WIP_PROVIDER_ID
+    description: The name of the environment variable containing the workload identity pool provider to use to authenticate to GCP
+  service-account-email:
+    type: env_var_name
+    default: GCP_SERVICE_ACCOUNT_EMAIL
+    description: The name of the environment variable containing the service account email to use to authenticate to GCP
+  gcp-cred-config-file-path:
+    type: string
+    default: /tmp/circleci-gcp_cred_config.json
+    description: The full path to the file used to store GCP OIDC Authentication configuration. This is an internal value and should only be changed if the default file conflicts with your needs
+  oidc-token-file-path:
+    type: string
+    default: /tmp/circleci-oidc_token.json
+    description: The full path to the file used to store the CCI-provided OIDC token. This is an internal value and should only be changed if the default file conflicts with your needs
+steps:
+  - run:
+      name: Set up GCP authentication details
+      command: |
+        # Store OIDC Token in temp file
+        echo $CIRCLE_OIDC_TOKEN > << parameters.oidc-token-file-path >>
+        # Create a credential config for the generated OIDC ID Token
+        gcloud iam workload-identity-pools create-cred-config \
+          "projects/${<< parameters.project-id >>}/locations/global/workloadIdentityPools/${<< parameters.workload-identity-pool-id >>}/providers/${<< parameters.workload-identity-pool-provider-id >>}" \
+          --output-file="<< parameters.gcp-cred-config-file-path >>" \
+          --service-account="${<< parameters.service-account-email >>}" \
+          --credential-source-file=<< parameters.oidc-token-file-path >>
+  - run:
+      name: GCloud auth
+      command:  gcloud auth login --cred-file "<< parameters.gcp-cred-config-file-path >>"
+  - run:
+      name: Container related registry logins
+      command: |
+        if [ -n "<< parameters.do-docker-login >>" ]; then
+          gcloud auth configure-docker --quiet us-central1-docker.pkg.dev,gcr.io
+        fi
+
+        if [ -n "<< parameters.do-helm-login >>" ]; then
+        export GOOGLE_APPLICATION_CREDENTIALS="<< parameters.gcp-cred-config-file-path >>"
+        gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+        fi
+  - run:
+      name: Set up Application Default Credentials (ADC)
+      command: |
+        if [ -n "<< parameters.do-activate-application-default-creds >>" ]; then
+          export GOOGLE_APPLICATION_CREDENTIALS="<< parameters.gcp-cred-config-file-path >>"
+          echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp-cred-config-file-path >>'" >> "$BASH_ENV"
+        fi
+  - run:
+      name: Delete cred files
+      command: |
+        if [ "<< parameters.delete-cred-file >>" == "true" ]; then
+          rm << parameters.oidc-token-file-path >>
+          rm << parameters.gcp-cred-config-file-path >>
+        fi

--- a/src/commands/gcp-oidc-authorize.yml
+++ b/src/commands/gcp-oidc-authorize.yml
@@ -68,7 +68,7 @@ steps:
       name: GCloud auth
       command:  gcloud auth login --cred-file "<< parameters.gcp-cred-config-file-path >>"
   - run:
-      name: Container related registry logins
+      name: Registry logins
       command: |
         if [ -n "<< parameters.do-docker-login >>" ]; then
           gcloud auth configure-docker --quiet << parameters.docker-registry-url >>

--- a/src/commands/gcp-oidc-authorize.yml
+++ b/src/commands/gcp-oidc-authorize.yml
@@ -4,12 +4,20 @@ parameters:
     type: enum
     default: ""
     enum: ["", "true"]
-    description: "Have Docker use the retrieved creds to log into Google Artifact Registry, where we have a Docker registry. Likely will need to run setup_remote_docker command first. "
+    description: "Have Docker use the retrieved creds to log into Google Artifact Registry, where we have a Docker registry. Likely will need to run setup_remote_docker command first."
+  docker-registry-url:
+    type: string
+    default: "us-central1-docker.pkg.dev,gcr.io"
+    description: A comma-separated list of Docker registries to which  this command should authenticate. This command configures authentication credentials via the GCloud CLI, so these will need to be hosted in GCP Artifact Registry. Only used if do-docker-login is true.
   do-helm-login:
     type: enum
     default: ""
     enum: ["", "true"]
     description: "Have Helm use the retrieved creds to log into Google Artifact Registry, using Helm's support for OCI registries."
+  helm-registry-url:
+    type: string
+    default: "https://us-central1-docker.pkg.dev"
+    description: The URL of the Helm Registry to which this command should authenticate. This command configures authentication credentials via the GCloud CLI, so this Helm Registry will need to be hosted in GCP Artifact Registry. Only used if do-helm-login is true.
   do-activate-application-default-creds:
     type: enum
     default: "true"
@@ -63,12 +71,12 @@ steps:
       name: Container related registry logins
       command: |
         if [ -n "<< parameters.do-docker-login >>" ]; then
-          gcloud auth configure-docker --quiet us-central1-docker.pkg.dev,gcr.io
+          gcloud auth configure-docker --quiet << parameters.docker-registry-url >>
         fi
 
         if [ -n "<< parameters.do-helm-login >>" ]; then
         export GOOGLE_APPLICATION_CREDENTIALS="<< parameters.gcp-cred-config-file-path >>"
-        gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+        gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin << parameters.helm-registry-url >>
         fi
   - run:
       name: Set up Application Default Credentials (ADC)


### PR DESCRIPTION
This adds the `gcp-oidc-authorize` command. 

This command is designed to act as a replacement for the existing `gcp-authorize` command. `gcp-authorize` requires a GCP Service Account's key be provided to the command. `gcp-oidc-authorize` does not take a key. Instead, it relies on [GCP Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) to grant access to GCP. This creates ephemeral, time-limited access credentials for a GCP project, eliminating static authentication material. 

To swap from `gcp-authorize` to `gcp-oidc-authorize`, users would need to 
1.  configure Workload Identity Federation for the GCP project(s) that they need to access and
2. arrange to set the requisite environment variables required by `gcp-oidc-authorize` on their pipelines. The envvar names for the various pieces of information required are configurable by parameters to the command. 

Because this creates a time-bound authenticated session, consumers will need to ensure that their pipelines generate authentication credentials temporally close to the commands that require communication with GCP. Workload Identity Federation sessions are valid for 60 minutes, so authenticated requests to GCP must occur within 60 minutes of `gcp-oidc-authorize` being invoked. 

Internally, the SecOps team has configured Workload Identity Federation for Apollo's primary GCP projects. Additionally, SecOps has Terraform available to facilitate creation of CCI contexts to provide the necessary environment variables to pipelines wishing to adopt `gcp-oidc-authorize`. Additional, internal information about using this command at Apollo is [available in Confluence](https://apollographql.atlassian.net/l/cp/CHouND1K).