### PR TITLE
Feature: Spin out the command circleci-long-job-cancle from the bulkier continue command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.2] - 2023-10-16
 
 - Added `circleci-long-job-cancel` as a way to spin off `circleci-continue-long-job-cancel` for workflows looking to avoid using `continue` based workflows.
+- Fixed `long_job_canceller` script to log moderately more. This fixes issues in CircleCI when it doesn't see output for too long due to no output detected.
 
 ## [1.3.1] - 2023-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2023-10-16
+
+- Added `circleci-long-job-cancel` as a way to spin off `circleci-continue-long-job-cancel` for workflows looking to avoid using `continue` based workflows.
+
 ## [1.3.1] - 2023-08-04
 
 - Added `gcp-oidc-authorize` as a new option for authenticating to GCP. This uses Open Identity Connect (OIDC) and the Identity Provider (IdP) that Circle makes available to jobs to authenticate to GCP via GCP's Workload Identity Federation. See [Circle's Docs](https://circleci.com/docs/openid-connect-tokens/#google-cloud-platform) for more info

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -20,12 +20,11 @@ parameters:
     default: 6
     type: integer
 steps:
-  - run:
-      name: Cancel long jobs
-      working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
-      command: |
-        python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore-job-names=<< parameters.ignore-when-all-on-hold-job-names-contain >>
+  - circleci-long-job-cancel:
+        org-repo-slug: << parameters.org-repo-slug >>
+        circle-ci-token-variable: << parameters.circleci-token-variable >>
+        ignore-when-all-on-hold-job-names-contain: << parameters.ignore-when-all-on-hold-job-names-contain >>
+        n-windows: << parameters.n-windows >>
   - run:
       name: Spawn workflow jobs for warnings
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/render-yaml-from-tsv

--- a/src/commands/circleci-continue-long-job-cancel.yml
+++ b/src/commands/circleci-continue-long-job-cancel.yml
@@ -22,7 +22,7 @@ parameters:
 steps:
   - circleci-long-job-cancel:
         org-repo-slug: << parameters.org-repo-slug >>
-        circle-ci-token-variable: << parameters.circleci-token-variable >>
+        circleci-token-variable: << parameters.circleci-token-variable >>
         ignore-when-all-on-hold-job-names-contain: << parameters.ignore-when-all-on-hold-job-names-contain >>
         n-windows: << parameters.n-windows >>
   - run:

--- a/src/commands/circleci-long-job-cancel.yml
+++ b/src/commands/circleci-long-job-cancel.yml
@@ -1,0 +1,27 @@
+description: for any job that is old, cancel it and warn the people. Must run the setup command on each new executor
+
+parameters:
+  org-repo-slug:
+    type: string
+    description: "github-username-or-org-name/repo-name"
+  circleci-token-variable:
+    description: the name of the environmental variable that contains the circleci token
+    default: "CIRCLECI_TOKEN"
+    type: string
+  ignore-when-all-on-hold-job-names-contain:
+    description: Do not warn about workflows where all of the on hold job names contain this string (also supported - comma seperated list)
+    type: string
+    default: ""
+  n-windows:
+    description: Number of windows to look back across. Default window length is 2 hours.
+    default: 6
+    type: integer
+steps:
+  - run:
+      name: Cancel long jobs
+      working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
+      command: |
+        python3 -m pip install -r requirements.txt
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore-job-names=<< parameters.ignore-when-all-on-hold-job-names-contain >>
+  - store_artifacts:
+        path: /tmp/circle/

--- a/src/commands/circleci-long-job-cancel.yml
+++ b/src/commands/circleci-long-job-cancel.yml
@@ -16,12 +16,30 @@ parameters:
     description: Number of windows to look back across. Default window length is 2 hours.
     default: 6
     type: integer
+  window-start-in-hours:
+    description: Number of hours ago to start search window. Default usage is the n-windows argument.
+    default: 0
+    type: integer
+  window-end-cancel-in-hours:
+    description: Number of hours ago to end search window for cancels. ie, if the Workflows found in the search window, are last updated _before_ this watermark, cancel them. Default usage is the n-windows argument.
+    default: 0
+    type: integer
+  window-end-warning-in-hours:
+    description: Number of hours ago to end search window for warnings. Assumes this is less than window-end-cancel-in-hours when present. Default usage is the n-windows argument.
+    default: 0
+    type: integer
 steps:
   - run:
       name: Cancel long jobs
       working_directory: /tmp/apollo_internal_platform_orb/src/scripts/circleci-job-canceller
       command: |
         python3 -m pip install -r requirements.txt
-        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> --commit --n-windows << parameters.n-windows >> --ignore-job-names=<< parameters.ignore-when-all-on-hold-job-names-contain >>
+        python3 long_job_canceller.py $<< parameters.circleci-token-variable >> << parameters.org-repo-slug >> \
+          --commit \
+          --n-windows << parameters.n-windows >> \
+          --ignore-job-names=<< parameters.ignore-when-all-on-hold-job-names-contain >> \
+          --window-start-in-hours << parameters.window-start-in-hours >> \
+          --window-end-cancel-in-hours << parameters.window-end-cancel-in-hours >> \
+          --window-end-warning-in-hours << parameters.window-end-warning-in-hours >>
   - store_artifacts:
         path: /tmp/circle/


### PR DESCRIPTION
# Motivation

Spinning this little command off so that it can be used outside a `continue` focused workflow.

## Notes

- Adds a few new parameters to things so that we can start migrating off of the `n-window` paradigm. Folks have been finding that confusing, and seems like we can just name the variables what they are 😅 
- Had to add more logging. Fixes issues with CCI timing out when it sees no activity for long periods of time.