### PR TITLE
Fix: Typo in variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2023-10-16
+
+- Fixed `long_job_canceller` script to log moderately more. This fixes issues in CircleCI when it doesn't see output for too long due to no output detected.
+
 ## [1.3.2] - 2023-10-16
 
 - Added `circleci-long-job-cancel` as a way to spin off `circleci-continue-long-job-cancel` for workflows looking to avoid using `continue` based workflows.

--- a/src/scripts/circleci-job-canceller/long_job_canceller.py
+++ b/src/scripts/circleci-job-canceller/long_job_canceller.py
@@ -213,6 +213,6 @@ if __name__ == "__main__":
     main(args.circleapitoken, args.orgreposlug,
          args.n_windows,
          args.window_start_in_hours,
-         args.window_cancel_end_in_hours,
-         args.window_warning_end_in_hours,
+         args.window_end_cancel_in_hours,
+         args.window_end_warning_in_hours,
          args.output_file, args.commit, args.ignore_job_names.split(","))


### PR DESCRIPTION
# Motivation

Introduced minor regression in the root python script for cancelling things with typo in 2 variable names.